### PR TITLE
Improve colorizing control

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           go-version: '1.19'
       - name: Build
-        run: ./goyek.sh -v all diff
+        run: ./goyek.sh -v -force-color all diff
 
   compatibility:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ## [Unreleased](https://github.com/goyek/goyek/compare/v0.1.1...HEAD)
 
+### Added
+
+- Add `color.Disable` disables colorizing the output.
+- Add `color.Force` forces colorizing the output.
+- Add `-no-color` and `-force-color` flags in `boot.Main`
+  to give more control on colorizing the output.
+
 ## [0.1.1](https://github.com/goyek/goyek/releases/tag/v0.1.1) - 2022-11-06
 
 This release bumps `goyek` to `2.0.0-rc.9`.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ offers functions for running programs in a Shell-like way.
 
 Package [`color`](https://pkg.go.dev/github.com/goyek/x/color)
 contains goyek features which additionally have colors.
+The package supports the [`NO_COLOR` environment variable](https://no-color.org/).
 
 ## Example
 

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -16,11 +16,13 @@ import (
 
 // Reusable flags used by the build pipeline.
 var (
-	v       = flag.Bool("v", false, "print all tasks and tests as they are run")
-	dryRun  = flag.Bool("dry-run", false, "print all tasks that would be run without running them")
-	longRun = flag.Duration("long-run", time.Minute, "print when a task takes longer")
-	noDeps  = flag.Bool("no-deps", false, "do not process dependencies")
-	skip    = flag.String("skip", "", "skip processing the `comma-separated tasks`")
+	v          = flag.Bool("v", false, "print all tasks and tests as they are run")
+	dryRun     = flag.Bool("dry-run", false, "print all tasks that would be run without running them")
+	longRun    = flag.Duration("long-run", time.Minute, "print when a task takes longer")
+	noDeps     = flag.Bool("no-deps", false, "do not process dependencies")
+	skip       = flag.String("skip", "", "skip processing the `comma-separated tasks`")
+	noColor    = flag.Bool("no-color", false, "disable colorizing output")
+	forceColor = flag.Bool("force-color", false, "force colorizing output")
 )
 
 // Main is an extension of goyek.Main which additionally
@@ -43,6 +45,12 @@ func Main() {
 	}
 	if *longRun > 0 {
 		goyek.Use(middleware.ReportLongRun(*longRun))
+	}
+	if *noColor {
+		color.Disable()
+	}
+	if *forceColor {
+		color.Force()
 	}
 
 	var opts []goyek.Option

--- a/color/color.go
+++ b/color/color.go
@@ -1,11 +1,15 @@
 // Package color contains goyek features which additionally
 // have colors.
+//
+// Set NO_COLOR environment variable to not an empty string to prevent the addition of colors.
+//
+// By default only TTY streams are colorized.
+// However, you can use ForceColor function to override this behavior.
 package color
 
 import (
 	"fmt"
 	"io"
-	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -15,8 +19,15 @@ import (
 	"github.com/goyek/goyek/v2"
 )
 
-func init() {
-	color.NoColor = os.Getenv("NO_COLOR") != ""
+// Force always colorized the output.
+// It bypasses the check for a non TTY output.
+func Force() {
+	color.NoColor = false
+}
+
+// Disable prevents colorizing the output.
+func Disable() {
+	color.NoColor = true
 }
 
 // ReportStatus is a middleware which reports the task run status with colors.


### PR DESCRIPTION
- Add `color.Disable` disables colorizing the output.
- Add `color.Force` forces colorizing the output.
- Add `-no-color` and `-force-color` flags in `boot.Main`
  to give more control on colorizing the output.