### PR TITLE
Release 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 as well as to [Module version numbering](https://go.dev/doc/modules/version-numbers).
 
-## [Unreleased](https://github.com/goyek/goyek/compare/v0.1.2...HEAD)
+## [Unreleased](https://github.com/goyek/goyek/compare/v0.1.3...HEAD)
+
+## [0.1.3](https://github.com/goyek/goyek/releases/tag/v0.1.3) - 2022-11-13
+
+### Fixed
+
+- Fix flag usage descriptions used in `boot.Main`.
 
 ## [0.1.2](https://github.com/goyek/goyek/releases/tag/v0.1.2) - 2022-11-13
 


### PR DESCRIPTION
### Fixed

- Fix flag usage descriptions used in `boot.Main`.