### PR TITLE
Release 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 as well as to [Module version numbering](https://go.dev/doc/modules/version-numbers).
 
-## [Unreleased](https://github.com/goyek/goyek/compare/v0.1.4...HEAD)
+## [0.1.5](https://github.com/goyek/x/releases/tag/v0.1.5) - 2023-02-08
 
-## [0.1.4](https://github.com/goyek/goyek/releases/tag/v0.1.4) - 2022-11-24
+### Changed
 
-This release bumps `goyek` to `2.0.0-rc.12`.
+- Bump `github.com/goyek/goyek` to `2.0.0`.
+- Bump `github.com/fatih/color` to `1.14.1`.
+
+## [0.1.4](https://github.com/goyek/x/releases/tag/v0.1.4) - 2022-11-24
+
+### Changed
+
+- Bump `github.com/goyek/goyek` to `2.0.0-rc.12`.
 
 ## [0.1.3](https://github.com/goyek/goyek/releases/tag/v0.1.3) - 2022-11-13
 
@@ -18,18 +25,18 @@ This release bumps `goyek` to `2.0.0-rc.12`.
 
 - Fix flag usage descriptions used in `boot.Main`.
 
-## [0.1.2](https://github.com/goyek/goyek/releases/tag/v0.1.2) - 2022-11-13
+## [0.1.2](https://github.com/goyek/x/releases/tag/v0.1.2) - 2022-11-13
 
 ### Added
 
 - Add `color.NoColor` function which disables colorizing the output.
 - Add `-no-color` flag to `boot.Main` that disables colorizing the output.
 
-## [0.1.1](https://github.com/goyek/goyek/releases/tag/v0.1.1) - 2022-11-06
+## [0.1.1](https://github.com/goyek/x/releases/tag/v0.1.1) - 2022-11-06
 
 This release bumps `goyek` to `2.0.0-rc.9`.
 
-## [0.1.0](https://github.com/goyek/goyek/releases/tag/v0.1.0) - 2022-11-01
+## [0.1.0](https://github.com/goyek/x/releases/tag/v0.1.0) - 2022-11-01
 
 This release primarily adds the `boot.Main` and `cmd.Exec` functions.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,6 @@ Create a pull request named `Release <version>` to update the [`CHANGELOG.md`](C
 - Change the `Unreleased` header to represent the new release.
 - Consider adding a description for the new release.
   Especially if it adds new features or introduces breaking changes.
-- Add a new `Unreleased` header above the new release, with no details.
 
 ### Release
 

--- a/build/go.mod
+++ b/build/go.mod
@@ -1,13 +1,13 @@
 module github.com/goyek/x/build
 
-go 1.19
+go 1.20
 
 replace github.com/goyek/x => ../
 
 require (
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.51.1
-	github.com/goyek/goyek/v2 v2.0.0-rc.12
+	github.com/goyek/goyek/v2 v2.0.0
 	github.com/goyek/x v0.0.0-00010101000000-000000000000
 )
 

--- a/build/go.sum
+++ b/build/go.sum
@@ -272,8 +272,8 @@ github.com/gostaticanalysis/nilerr v0.1.1 h1:ThE+hJP0fEp4zWLkWHWcRyI2Od0p7DlgYG3
 github.com/gostaticanalysis/nilerr v0.1.1/go.mod h1:wZYb6YI5YAxxq0i1+VJbY0s2YONW0HU0GPE3+5PWN4A=
 github.com/gostaticanalysis/testutil v0.3.1-0.20210208050101-bfb5c8eec0e4/go.mod h1:D+FIZ+7OahH3ePw/izIEeH5I06eKs1IKI4Xr64/Am3M=
 github.com/gostaticanalysis/testutil v0.4.0 h1:nhdCmubdmDF6VEatUNjgUZBJKWRqugoISdUv3PPQgHY=
-github.com/goyek/goyek/v2 v2.0.0-rc.12 h1:y0cYeaQYOQTmOwpTb7mBijla2HfaOtuSksJO7NeLnOo=
-github.com/goyek/goyek/v2 v2.0.0-rc.12/go.mod h1:qtHlK7t/dYs1Dw7mLXjEVmgE3nccNa7mQW/RmasOoYg=
+github.com/goyek/goyek/v2 v2.0.0 h1:/QAVDjTAsJ+caIoXNDSWs6jBHohh3CEzJ+vCcggjoWw=
+github.com/goyek/goyek/v2 v2.0.0/go.mod h1:qtHlK7t/dYs1Dw7mLXjEVmgE3nccNa7mQW/RmasOoYg=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/fatih/color v1.14.1
-	github.com/goyek/goyek/v2 v2.0.0-rc.12
+	github.com/goyek/goyek/v2 v2.0.0
 	github.com/mattn/go-shellwords v1.0.12
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/fatih/color v1.14.1 h1:qfhVLaG5s+nCROl1zJsZRxFeYrHLqWroPOQ8BWiNb4w=
 github.com/fatih/color v1.14.1/go.mod h1:2oHN61fhTpgcxD3TSWCgKDiH1+x4OiDVVGH8WlgGZGg=
-github.com/goyek/goyek/v2 v2.0.0-rc.12 h1:y0cYeaQYOQTmOwpTb7mBijla2HfaOtuSksJO7NeLnOo=
-github.com/goyek/goyek/v2 v2.0.0-rc.12/go.mod h1:qtHlK7t/dYs1Dw7mLXjEVmgE3nccNa7mQW/RmasOoYg=
+github.com/goyek/goyek/v2 v2.0.0 h1:/QAVDjTAsJ+caIoXNDSWs6jBHohh3CEzJ+vCcggjoWw=
+github.com/goyek/goyek/v2 v2.0.0/go.mod h1:qtHlK7t/dYs1Dw7mLXjEVmgE3nccNa7mQW/RmasOoYg=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=


### PR DESCRIPTION
### Changed

- Bump `github.com/goyek/goyek` to `2.0.0`.
- Bump `github.com/fatih/color` to `1.14.1`.