### PR TITLE
Bump markdownlint-cli to v0.36.0

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-pellared@hotmail.com.
+<pellared@hotmail.com>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/build/mdlint.go
+++ b/build/mdlint.go
@@ -25,7 +25,7 @@ var mdlint = goyek.Define(goyek.Task{
 		if len(mdFiles) == 0 {
 			a.Skip("no .md files")
 		}
-		dockerImage := "ghcr.io/igorshubovych/markdownlint-cli:v0.33.0"
+		dockerImage := "ghcr.io/igorshubovych/markdownlint-cli:v0.36.0"
 		cmd.Exec(a, "docker run --rm -v '"+curDir+":/workdir' "+dockerImage+" "+strings.Join(mdFiles, " "))
 	},
 })


### PR DESCRIPTION
https://github.com/igorshubovych/markdownlint-cli/releases/tag/v0.36.0