### PR TITLE
Add graphviz package for dependency graph visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ## [Unreleased](https://github.com/goyek/x/compare/v0.4.0...HEAD)
 
+### Added
+
+- Add `graphviz.Draw` function which visualizes a dependency graph with registered tasks.
+
 ### Removed
 
 - Drop support for Go 1.23.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ### Added
 
-- Add `graphviz.Draw` function which visualizes a dependency graph with registered tasks.
+- Add `graphviz.Draw` function which visualizes a dependency graph with
+  registered tasks.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ### Added
 
-- Add `graphviz.Draw` function which visualizes a dependency graph with
-  registered tasks.
+- Add `graphviz.Draw` function which visualizes a dependency graph
+  with registered tasks.
+- Add `-graph` flag to `boot.Main` to output the task dependency graph
+  in DOT format.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ which additionally defines flags and configures the flow in a convenient way.
 Package [`cmd`](https://pkg.go.dev/github.com/goyek/x/cmd)
 offers functions for running programs in a Shell-like way.
 
+Package [`graphviz`](https://pkg.go.dev/github.com/goyek/x/graphviz)
+visualizes a dependency graph with registered tasks.
+
 Package [`color`](https://pkg.go.dev/github.com/goyek/x/color)
 contains goyek features which additionally have colors.
 The package supports the [`NO_COLOR`](https://no-color.org/)

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ which additionally defines flags and configures the flow in a convenient way.
 Package [`cmd`](https://pkg.go.dev/github.com/goyek/x/cmd)
 offers functions for running programs in a Shell-like way.
 
-Package [`graphviz`](https://pkg.go.dev/github.com/goyek/x/graphviz)
-visualizes a dependency graph with registered tasks.
-
 Package [`color`](https://pkg.go.dev/github.com/goyek/x/color)
 contains goyek features which additionally have colors.
 The package supports the [`NO_COLOR`](https://no-color.org/)
 environment variable.
+
+Package [`graphviz`](https://pkg.go.dev/github.com/goyek/x/graphviz)
+visualizes a dependency graph with registered tasks.
 
 Package [`otelgoyek`](https://pkg.go.dev/github.com/goyek/x/otelgoyek)
 provides OpenTelemetry instrumentation for goyek.

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -13,6 +13,7 @@ import (
 	"github.com/goyek/goyek/v3/middleware"
 
 	"github.com/goyek/x/color"
+	"github.com/goyek/x/graphviz"
 )
 
 const exitCodeInvalid = 2
@@ -25,6 +26,7 @@ var (
 	noDeps  = flag.Bool("no-deps", false, "do not process dependencies")
 	skip    = flag.String("skip", "", "skip processing the `comma-separated tasks`")
 	noColor = flag.Bool("no-color", false, "disable colorizing output")
+	graph   = flag.Bool("graph", false, "output the task dependency graph in DOT format and exit")
 )
 
 // Main is an extension of goyek.Main which additionally defines reusable flags
@@ -45,6 +47,14 @@ func Main() {
 	if err := flag.CommandLine.Parse(args); err != nil {
 		fmt.Fprintln(goyek.Output(), err)
 		os.Exit(exitCodeInvalid)
+	}
+
+	if *graph {
+		if err := graphviz.Draw(goyek.Output(), goyek.DefaultFlow); err != nil {
+			fmt.Fprintln(goyek.Output(), err)
+			os.Exit(1)
+		}
+		os.Exit(0)
 	}
 
 	if *dryRun {

--- a/graphviz/example_test.go
+++ b/graphviz/example_test.go
@@ -1,0 +1,32 @@
+package graphviz_test
+
+import (
+	"os"
+
+	"github.com/goyek/goyek/v3"
+	"github.com/goyek/x/graphviz"
+)
+
+func ExampleDraw() {
+	f := &goyek.Flow{}
+	test := f.Define(goyek.Task{
+		Name:  "test",
+		Usage: "run tests",
+	})
+	f.Define(goyek.Task{
+		Name:  "all",
+		Usage: "run all tasks",
+		Deps:  goyek.Deps{test},
+	})
+
+	if err := graphviz.Draw(os.Stdout, f); err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// digraph G {
+	//   "all";
+	//   "all" -> "test";
+	//   "test";
+	// }
+}

--- a/graphviz/example_test.go
+++ b/graphviz/example_test.go
@@ -25,8 +25,8 @@ func ExampleDraw() {
 
 	// Output:
 	// digraph G {
-	//   "all";
+	//   "all" [tooltip="run all tasks"];
 	//   "all" -> "test";
-	//   "test";
+	//   "test" [tooltip="run tests"];
 	// }
 }

--- a/graphviz/graphviz.go
+++ b/graphviz/graphviz.go
@@ -36,8 +36,14 @@ func Draw(w io.Writer, flow *goyek.Flow, opts ...Option) error {
 	}
 
 	for _, task := range flow.Tasks() {
-		if _, err := fmt.Fprintf(w, "  %q;\n", task.Name()); err != nil {
-			return err
+		if usage := task.Usage(); usage != "" {
+			if _, err := fmt.Fprintf(w, "  %q [tooltip=%q];\n", task.Name(), usage); err != nil {
+				return err
+			}
+		} else {
+			if _, err := fmt.Fprintf(w, "  %q;\n", task.Name()); err != nil {
+				return err
+			}
 		}
 		for _, dep := range task.Deps() {
 			if _, err := fmt.Fprintf(w, "  %q -> %q;\n", task.Name(), dep.Name()); err != nil {

--- a/graphviz/graphviz.go
+++ b/graphviz/graphviz.go
@@ -1,0 +1,54 @@
+// Package graphviz visualizes a dependency graph with registered tasks.
+package graphviz
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/goyek/goyek/v3"
+)
+
+// Option configures the Graphviz drawing.
+type Option interface {
+	apply(*config)
+}
+
+type config struct {
+}
+
+// Draw visualizes a dependency graph with registered tasks in DOT format.
+func Draw(w io.Writer, flow *goyek.Flow, opts ...Option) error {
+	if w == nil {
+		return errors.New("nil writer")
+	}
+	if flow == nil {
+		return errors.New("nil flow")
+	}
+
+	cfg := &config{}
+	for _, opt := range opts {
+		opt.apply(cfg)
+	}
+
+	if _, err := io.WriteString(w, "digraph G {\n"); err != nil {
+		return err
+	}
+
+	for _, task := range flow.Tasks() {
+		if _, err := fmt.Fprintf(w, "  %q;\n", task.Name()); err != nil {
+			return err
+		}
+		for _, dep := range task.Deps() {
+			if _, err := fmt.Fprintf(w, "  %q -> %q;\n", task.Name(), dep.Name()); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := io.WriteString(w, "}\n"); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/graphviz/graphviz.go
+++ b/graphviz/graphviz.go
@@ -14,12 +14,6 @@ type Option interface {
 	apply(*config)
 }
 
-type optionFunc func(*config)
-
-func (fn optionFunc) apply(cfg *config) {
-	fn(cfg)
-}
-
 type config struct {
 }
 

--- a/graphviz/graphviz.go
+++ b/graphviz/graphviz.go
@@ -14,6 +14,12 @@ type Option interface {
 	apply(*config)
 }
 
+type optionFunc func(*config)
+
+func (fn optionFunc) apply(cfg *config) {
+	fn(cfg)
+}
+
 type config struct {
 }
 

--- a/graphviz/graphviz_test.go
+++ b/graphviz/graphviz_test.go
@@ -1,0 +1,101 @@
+package graphviz_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+	"github.com/goyek/x/graphviz"
+)
+
+func TestDraw(t *testing.T) {
+	t.Run("nil writer", func(t *testing.T) {
+		err := graphviz.Draw(nil, &goyek.Flow{})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("nil flow", func(t *testing.T) {
+		err := graphviz.Draw(&strings.Builder{}, nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty flow", func(t *testing.T) {
+		f := &goyek.Flow{}
+		sb := &strings.Builder{}
+		err := graphviz.Draw(sb, f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := sb.String()
+		want := "digraph G {\n}\n"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("single task", func(t *testing.T) {
+		f := &goyek.Flow{}
+		f.Define(goyek.Task{Name: "build"})
+		sb := &strings.Builder{}
+		err := graphviz.Draw(sb, f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := sb.String()
+		if !strings.Contains(got, "  \"build\";\n") {
+			t.Errorf("missing node declaration, got:\n%s", got)
+		}
+	})
+
+	t.Run("task with dependencies", func(t *testing.T) {
+		f := &goyek.Flow{}
+		test := f.Define(goyek.Task{Name: "test"})
+		lint := f.Define(goyek.Task{Name: "lint"})
+		f.Define(goyek.Task{
+			Name: "all",
+			Deps: goyek.Deps{test, lint},
+		})
+		sb := &strings.Builder{}
+		err := graphviz.Draw(sb, f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := sb.String()
+		if !strings.Contains(got, "  \"all\" -> \"test\";\n") {
+			t.Errorf("missing edge all -> test, got:\n%s", got)
+		}
+		if !strings.Contains(got, "  \"all\" -> \"lint\";\n") {
+			t.Errorf("missing edge all -> lint, got:\n%s", got)
+		}
+	})
+
+	t.Run("diamond dependency", func(t *testing.T) {
+		f := &goyek.Flow{}
+		d := f.Define(goyek.Task{Name: "D"})
+		b := f.Define(goyek.Task{Name: "B", Deps: goyek.Deps{d}})
+		c := f.Define(goyek.Task{Name: "C", Deps: goyek.Deps{d}})
+		f.Define(goyek.Task{Name: "A", Deps: goyek.Deps{b, c}})
+
+		sb := &strings.Builder{}
+		err := graphviz.Draw(sb, f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := sb.String()
+		edges := []string{
+			"  \"A\" -> \"B\";\n",
+			"  \"A\" -> \"C\";\n",
+			"  \"B\" -> \"D\";\n",
+			"  \"C\" -> \"D\";\n",
+		}
+		for _, edge := range edges {
+			if !strings.Contains(got, edge) {
+				t.Errorf("missing edge %q, got:\n%s", edge, got)
+			}
+		}
+	})
+}

--- a/graphviz/graphviz_test.go
+++ b/graphviz/graphviz_test.go
@@ -51,6 +51,20 @@ func TestDraw(t *testing.T) {
 		}
 	})
 
+	t.Run("task with usage", func(t *testing.T) {
+		f := &goyek.Flow{}
+		f.Define(goyek.Task{Name: "build", Usage: "compiles the code"})
+		sb := &strings.Builder{}
+		err := graphviz.Draw(sb, f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := sb.String()
+		if !strings.Contains(got, "  \"build\" [tooltip=\"compiles the code\"];\n") {
+			t.Errorf("missing tooltip, got:\n%s", got)
+		}
+	})
+
 	t.Run("task with dependencies", func(t *testing.T) {
 		f := &goyek.Flow{}
 		test := f.Define(goyek.Task{Name: "test"})

--- a/graphviz/graphviz_test.go
+++ b/graphviz/graphviz_test.go
@@ -8,108 +8,106 @@ import (
 	"github.com/goyek/x/graphviz"
 )
 
-func TestDraw(t *testing.T) {
-	t.Run("nil writer", func(t *testing.T) {
-		err := graphviz.Draw(nil, &goyek.Flow{})
-		if err == nil {
-			t.Fatal("expected error")
-		}
-	})
+func TestDraw_NilWriter(t *testing.T) {
+	err := graphviz.Draw(nil, &goyek.Flow{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
 
-	t.Run("nil flow", func(t *testing.T) {
-		err := graphviz.Draw(&strings.Builder{}, nil)
-		if err == nil {
-			t.Fatal("expected error")
-		}
-	})
+func TestDraw_NilFlow(t *testing.T) {
+	err := graphviz.Draw(&strings.Builder{}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
 
-	t.Run("empty flow", func(t *testing.T) {
-		f := &goyek.Flow{}
-		sb := &strings.Builder{}
-		err := graphviz.Draw(sb, f)
-		if err != nil {
-			t.Fatal(err)
-		}
-		got := sb.String()
-		want := "digraph G {\n}\n"
-		if got != want {
-			t.Errorf("got %q, want %q", got, want)
-		}
-	})
+func TestDraw_EmptyFlow(t *testing.T) {
+	f := &goyek.Flow{}
+	sb := &strings.Builder{}
+	err := graphviz.Draw(sb, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := sb.String()
+	want := "digraph G {\n}\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
 
-	t.Run("single task", func(t *testing.T) {
-		f := &goyek.Flow{}
-		f.Define(goyek.Task{Name: "build"})
-		sb := &strings.Builder{}
-		err := graphviz.Draw(sb, f)
-		if err != nil {
-			t.Fatal(err)
-		}
-		got := sb.String()
-		if !strings.Contains(got, "  \"build\";\n") {
-			t.Errorf("missing node declaration, got:\n%s", got)
-		}
-	})
+func TestDraw_SingleTask(t *testing.T) {
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{Name: "build"})
+	sb := &strings.Builder{}
+	err := graphviz.Draw(sb, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := sb.String()
+	if !strings.Contains(got, "  \"build\";\n") {
+		t.Errorf("missing node declaration, got:\n%s", got)
+	}
+}
 
-	t.Run("task with usage", func(t *testing.T) {
-		f := &goyek.Flow{}
-		f.Define(goyek.Task{Name: "build", Usage: "compiles the code"})
-		sb := &strings.Builder{}
-		err := graphviz.Draw(sb, f)
-		if err != nil {
-			t.Fatal(err)
-		}
-		got := sb.String()
-		if !strings.Contains(got, "  \"build\" [tooltip=\"compiles the code\"];\n") {
-			t.Errorf("missing tooltip, got:\n%s", got)
-		}
-	})
+func TestDraw_TaskWithUsage(t *testing.T) {
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{Name: "build", Usage: "compiles the code"})
+	sb := &strings.Builder{}
+	err := graphviz.Draw(sb, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := sb.String()
+	if !strings.Contains(got, "  \"build\" [tooltip=\"compiles the code\"];\n") {
+		t.Errorf("missing tooltip, got:\n%s", got)
+	}
+}
 
-	t.Run("task with dependencies", func(t *testing.T) {
-		f := &goyek.Flow{}
-		test := f.Define(goyek.Task{Name: "test"})
-		lint := f.Define(goyek.Task{Name: "lint"})
-		f.Define(goyek.Task{
-			Name: "all",
-			Deps: goyek.Deps{test, lint},
-		})
-		sb := &strings.Builder{}
-		err := graphviz.Draw(sb, f)
-		if err != nil {
-			t.Fatal(err)
-		}
-		got := sb.String()
-		if !strings.Contains(got, "  \"all\" -> \"test\";\n") {
-			t.Errorf("missing edge all -> test, got:\n%s", got)
-		}
-		if !strings.Contains(got, "  \"all\" -> \"lint\";\n") {
-			t.Errorf("missing edge all -> lint, got:\n%s", got)
-		}
+func TestDraw_TaskWithDependencies(t *testing.T) {
+	f := &goyek.Flow{}
+	test := f.Define(goyek.Task{Name: "test"})
+	lint := f.Define(goyek.Task{Name: "lint"})
+	f.Define(goyek.Task{
+		Name: "all",
+		Deps: goyek.Deps{test, lint},
 	})
+	sb := &strings.Builder{}
+	err := graphviz.Draw(sb, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := sb.String()
+	if !strings.Contains(got, "  \"all\" -> \"test\";\n") {
+		t.Errorf("missing edge all -> test, got:\n%s", got)
+	}
+	if !strings.Contains(got, "  \"all\" -> \"lint\";\n") {
+		t.Errorf("missing edge all -> lint, got:\n%s", got)
+	}
+}
 
-	t.Run("diamond dependency", func(t *testing.T) {
-		f := &goyek.Flow{}
-		d := f.Define(goyek.Task{Name: "D"})
-		b := f.Define(goyek.Task{Name: "B", Deps: goyek.Deps{d}})
-		c := f.Define(goyek.Task{Name: "C", Deps: goyek.Deps{d}})
-		f.Define(goyek.Task{Name: "A", Deps: goyek.Deps{b, c}})
+func TestDraw_DiamondDependency(t *testing.T) {
+	f := &goyek.Flow{}
+	d := f.Define(goyek.Task{Name: "D"})
+	b := f.Define(goyek.Task{Name: "B", Deps: goyek.Deps{d}})
+	c := f.Define(goyek.Task{Name: "C", Deps: goyek.Deps{d}})
+	f.Define(goyek.Task{Name: "A", Deps: goyek.Deps{b, c}})
 
-		sb := &strings.Builder{}
-		err := graphviz.Draw(sb, f)
-		if err != nil {
-			t.Fatal(err)
+	sb := &strings.Builder{}
+	err := graphviz.Draw(sb, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := sb.String()
+	edges := []string{
+		"  \"A\" -> \"B\";\n",
+		"  \"A\" -> \"C\";\n",
+		"  \"B\" -> \"D\";\n",
+		"  \"C\" -> \"D\";\n",
+	}
+	for _, edge := range edges {
+		if !strings.Contains(got, edge) {
+			t.Errorf("missing edge %q, got:\n%s", edge, got)
 		}
-		got := sb.String()
-		edges := []string{
-			"  \"A\" -> \"B\";\n",
-			"  \"A\" -> \"C\";\n",
-			"  \"B\" -> \"D\";\n",
-			"  \"C\" -> \"D\";\n",
-		}
-		for _, edge := range edges {
-			if !strings.Contains(got, edge) {
-				t.Errorf("missing edge %q, got:\n%s", edge, got)
-			}
-		}
-	})
+	}
 }


### PR DESCRIPTION
Fixes #210.

Add `graphviz` package.

The new package provides a `Draw` function that takes a `goyek.Flow` and writes its task dependency graph in Graphviz's DOT format to an `io.Writer`.

Key features:
- **`graphviz.Draw`**: The main function for generating the DOT output.
- **Support for functional options**: Included an `Option` interface for future configuration extensibility.
- **Robustness**: Handles nil inputs, empty flows, and complex dependency structures (like diamond dependencies).
- **Correctness**: Uses proper quoting (`%q`) for task names to ensure valid DOT output even with special characters or spaces.
- **Documentation**: Added an `ExampleDraw` function and updated the main `README.md`.
- **Testing**: Comprehensive tests in `graphviz_test.go`.

---
*PR created automatically by Jules for task [14678040163780611317](https://jules.google.com/task/14678040163780611317) started by @pellared*