### PR TITLE
Redact environment variable values from logs in cmd package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 - Add `-graph` flag to `boot.Main` to output the task dependency graph
   in DOT format.
 
+### Security
+
+- Redact environment variable values from logs in `cmd.Env`.
+
 ### Removed
 
 - Drop support for Go 1.23.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -58,8 +58,8 @@ func Dir(s string) Option {
 func Env(k, v string) Option {
 	return func(a *goyek.A, cmd *exec.Cmd) {
 		a.Helper()
+		a.Log("Env: ", k)
 		env := k + "=" + v
-		a.Log("Env: ", env)
 		cmd.Env = append(cmd.Env, env)
 	}
 }

--- a/cmd/security_test.go
+++ b/cmd/security_test.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"context"
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestEnvLogging(t *testing.T) {
+	sb := &strings.Builder{}
+
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = io.MultiWriter(in.Output, sb)
+			return next(in)
+		}
+	}
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			Env("SECRET_KEY", "very-sensitive-value")(a, &exec.Cmd{})
+		},
+	})
+
+	// Use the middleware to capture output
+	// goyek.Use is global, but Flow might have its own?
+	// Actually goyek.Use affects DefaultFlow.
+	// For a custom Flow, we might need another way or just use DefaultFlow.
+
+	oldFlow := goyek.DefaultFlow
+	defer func() { goyek.DefaultFlow = oldFlow }()
+	goyek.DefaultFlow = f
+	goyek.Use(mw)
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	if strings.Contains(got, "very-sensitive-value") {
+		t.Errorf("Secret value was logged: %s", got)
+	}
+	if !strings.Contains(got, "SECRET_KEY") {
+		t.Errorf("Env key was not logged: %s", got)
+	}
+}


### PR DESCRIPTION
Identified and fixed a security issue in the `cmd` package where the `Env` option would log the full value of environment variables. This could lead to sensitive information such as API keys or passwords being leaked into build logs.

Changes:
- Modified `cmd/cmd.go`: Updated `Env` function to log only the key.
- Added `cmd/security_test.go`: Included a reproduction and verification test case that uses a `goyek` middleware to capture and inspect log output.

The fix was verified by ensuring the test case passes (no sensitive value in logs) and that all other tests in the repository continue to pass.

---
*PR created automatically by Jules for task [2993036298886408474](https://jules.google.com/task/2993036298886408474) started by @pellared*