### PR TITLE
Redact environment variable values in cmd.Exec logs

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/goyek/goyek/v3"
 	"github.com/mattn/go-shellwords"
@@ -37,7 +38,21 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 		opt(a, cmd)
 	}
 
-	a.Log("Exec: ", cmdLine)
+	var sb strings.Builder
+	sb.WriteString("Exec:")
+	for _, env := range envs {
+		if k, _, ok := strings.Cut(env, "="); ok {
+			sb.WriteString(" ")
+			sb.WriteString(k)
+			sb.WriteString("=[REDACTED]")
+		}
+	}
+	for _, arg := range args {
+		sb.WriteString(" ")
+		sb.WriteString(arg)
+	}
+	a.Log(sb.String())
+
 	if err := cmd.Run(); err != nil {
 		a.Error(err)
 		return false

--- a/cmd/security_test.go
+++ b/cmd/security_test.go
@@ -48,3 +48,40 @@ func TestEnvLogging(t *testing.T) {
 		t.Errorf("Env key was not logged: %s", got)
 	}
 }
+
+func TestExecLoggingRedaction(t *testing.T) {
+	sb := &strings.Builder{}
+
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = io.MultiWriter(in.Output, sb)
+			return next(in)
+		}
+	}
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			Exec(a, "PASSWORD=secret go version")
+		},
+	})
+
+	oldFlow := goyek.DefaultFlow
+	defer func() { goyek.DefaultFlow = oldFlow }()
+	goyek.DefaultFlow = f
+	goyek.Use(mw)
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	if strings.Contains(got, "secret") {
+		t.Errorf("Secret value was logged: %s", got)
+	}
+	if !strings.Contains(got, "PASSWORD=[REDACTED]") {
+		t.Errorf("Env key was not logged with [REDACTED]: %s", got)
+	}
+	if !strings.Contains(got, "go version") {
+		t.Errorf("Command was not logged: %s", got)
+	}
+}


### PR DESCRIPTION
This PR enhances the security of the `cmd` package by ensuring that environment variable values provided within the command string passed to `cmd.Exec` are redacted in the logs.

Previously, `cmd.Exec(a, "TOKEN=secret-123 ./deploy.sh")` would log:
`Exec: TOKEN=secret-123 ./deploy.sh`

Now it will log:
`Exec: TOKEN=[REDACTED] ./deploy.sh`

This prevents accidental leakage of secrets in build outputs and CI/CD logs.

---
*PR created automatically by Jules for task [11959929765418638306](https://jules.google.com/task/11959929765418638306) started by @pellared*