### PR TITLE
Redact secrets in cmd.Exec logs

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/goyek/goyek/v3"
 	"github.com/mattn/go-shellwords"
@@ -37,7 +38,21 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 		opt(a, cmd)
 	}
 
-	a.Log("Exec: ", cmdLine)
+	var sb strings.Builder
+	sb.WriteString("Exec: ")
+	for _, env := range envs {
+		split := strings.SplitN(env, "=", 2)
+		sb.WriteString(split[0])
+		sb.WriteString("=[REDACTED] ")
+	}
+	for i, arg := range args {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(arg)
+	}
+	a.Log(sb.String())
+
 	if err := cmd.Run(); err != nil {
 		a.Error(err)
 		return false

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -41,7 +41,7 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	var sb strings.Builder
 	sb.WriteString("Exec: ")
 	for _, env := range envs {
-		split := strings.SplitN(env, "=", 2)
+		split := strings.SplitN(env, "=", 2) //nolint:mnd // it is used to split key and value
 		sb.WriteString(split[0])
 		sb.WriteString("=[REDACTED] ")
 	}

--- a/cmd/security_test.go
+++ b/cmd/security_test.go
@@ -28,11 +28,6 @@ func TestEnvLogging(t *testing.T) {
 		},
 	})
 
-	// Use the middleware to capture output
-	// goyek.Use is global, but Flow might have its own?
-	// Actually goyek.Use affects DefaultFlow.
-	// For a custom Flow, we might need another way or just use DefaultFlow.
-
 	oldFlow := goyek.DefaultFlow
 	defer func() { goyek.DefaultFlow = oldFlow }()
 	goyek.DefaultFlow = f
@@ -46,5 +41,36 @@ func TestEnvLogging(t *testing.T) {
 	}
 	if !strings.Contains(got, "SECRET_KEY") {
 		t.Errorf("Env key was not logged: %s", got)
+	}
+}
+
+func TestExecLogging(t *testing.T) {
+	sb := &strings.Builder{}
+
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = io.MultiWriter(in.Output, sb)
+			return next(in)
+		}
+	}
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			Exec(a, "SECRET_KEY=very-sensitive-value go version")
+		},
+	})
+
+	oldFlow := goyek.DefaultFlow
+	defer func() { goyek.DefaultFlow = oldFlow }()
+	goyek.DefaultFlow = f
+	goyek.Use(mw)
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	if strings.Contains(got, "very-sensitive-value") {
+		t.Errorf("Secret value was logged: %s", got)
 	}
 }

--- a/graphviz/example_test.go
+++ b/graphviz/example_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/goyek/goyek/v3"
+
 	"github.com/goyek/x/graphviz"
 )
 

--- a/graphviz/graphviz.go
+++ b/graphviz/graphviz.go
@@ -14,8 +14,7 @@ type Option interface {
 	apply(*config)
 }
 
-type config struct {
-}
+type config struct{}
 
 // Draw visualizes a dependency graph with registered tasks in DOT format.
 func Draw(w io.Writer, flow *goyek.Flow, opts ...Option) error {

--- a/graphviz/graphviz_test.go
+++ b/graphviz/graphviz_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/goyek/goyek/v3"
+
 	"github.com/goyek/x/graphviz"
 )
 


### PR DESCRIPTION
Redact inline environment variable values in `cmd.Exec` logs to prevent accidental leakage of secrets. Added tests to verify the redaction.

---
*PR created automatically by Jules for task [1765351373559339034](https://jules.google.com/task/1765351373559339034) started by @pellared*