### PR TITLE
cmd: remove logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 - Add `-graph` flag to `boot.Main` to output the task dependency graph
   in DOT format.
 
-### Security
+### Changed
 
-- Redact environment variable values from logs in `cmd.Env`.
+- Remove logging from `cmd.Exec`, `cmd.Dir`, and `cmd.Env` to prevent sensitive information leakage.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 All notable changes to this library are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
-as well as to [Module version numbering](https://go.dev/doc/modules/version-numbers).
+and this library adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html) as well as to
+[Module version numbering](https://go.dev/doc/modules/version-numbers).
 
 ## [Unreleased](https://github.com/goyek/x/compare/v0.4.0...HEAD)
 
@@ -28,8 +29,9 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ### Changed
 
-- **BREAKING**: Change `boot.Main` command line syntax from `[flags] [--] [tasks]`
-  to `[tasks] [flags] [--] [args]` to align with `goyek` v3 recommendation.
+- **BREAKING**: Change `boot.Main` command line syntax from
+  `[flags] [--] [tasks]` to `[tasks] [flags] [--] [args]` to align with
+  `goyek` v3 recommendation.
 - Bump `github.com/goyek/goyek` to `3.0.0`.
 - Bump other dependencies.
 
@@ -132,12 +134,6 @@ This release primarily adds the `boot.Main` and `cmd.Exec` functions.
 {
   "MD024": {
     "siblings_only": true
-  },
-  "MD013": {
-    "line_length": 80,
-    "code_blocks": false,
-    "tables": false,
-    "headings": false
   }
 }
 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ as well as to [Module version numbering](https://go.dev/doc/modules/version-numb
 
 ### Changed
 
-- Remove logging from `cmd.Exec`, `cmd.Dir`, and `cmd.Env` to prevent sensitive information leakage.
+- Remove logging from `cmd.Exec`, `cmd.Dir`, and `cmd.Env` to prevent sensitive
+  information leakage.
 
 ### Removed
 
@@ -131,6 +132,12 @@ This release primarily adds the `boot.Main` and `cmd.Exec` functions.
 {
   "MD024": {
     "siblings_only": true
+  },
+  "MD013": {
+    "line_length": 80,
+    "code_blocks": false,
+    "tables": false,
+    "headings": false
   }
 }
 -->

--- a/build/diff.go
+++ b/build/diff.go
@@ -13,13 +13,11 @@ var _ = goyek.Define(goyek.Task{
 	Name:  "diff",
 	Usage: "git diff",
 	Action: func(a *goyek.A) {
-		a.Log("git diff --exit-code")
-		cmd.Exec(a, "git diff --exit-code")
+		runExec(a, "git diff --exit-code")
 
 		sb := &strings.Builder{}
 		out := io.MultiWriter(a.Output(), sb)
-		a.Log("git status --porcelain")
-		cmd.Exec(a, "git status --porcelain", cmd.Stdout(out), cmd.Stderr(out))
+		runExec(a, "git status --porcelain", cmd.Stdout(out), cmd.Stderr(out))
 		if sb.Len() > 0 {
 			a.Error("git status --porcelain returned output")
 		}

--- a/build/diff.go
+++ b/build/diff.go
@@ -13,10 +13,12 @@ var _ = goyek.Define(goyek.Task{
 	Name:  "diff",
 	Usage: "git diff",
 	Action: func(a *goyek.A) {
+		a.Log("git diff --exit-code")
 		cmd.Exec(a, "git diff --exit-code")
 
 		sb := &strings.Builder{}
 		out := io.MultiWriter(a.Output(), sb)
+		a.Log("git status --porcelain")
 		cmd.Exec(a, "git status --porcelain", cmd.Stdout(out), cmd.Stderr(out))
 		if sb.Len() > 0 {
 			a.Error("git status --porcelain returned output")

--- a/build/helper.go
+++ b/build/helper.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/goyek/goyek/v3"
+
+	"github.com/goyek/x/cmd"
+)
+
+func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
+	a.Helper()
+	a.Log("Exec: ", cmdLine)
+	return cmd.Exec(a, cmdLine, opts...)
+}
+
+func runDir(a *goyek.A, s string) cmd.Option {
+	a.Helper()
+	a.Log("Work dir: ", s)
+	return cmd.Dir(s)
+}

--- a/build/lint.go
+++ b/build/lint.go
@@ -2,21 +2,16 @@ package main
 
 import (
 	"github.com/goyek/goyek/v3"
-
-	"github.com/goyek/x/cmd"
 )
 
 var lint = goyek.Define(goyek.Task{
 	Name:  "lint",
 	Usage: "golangci-lint run --fix",
 	Action: func(a *goyek.A) {
-		a.Log("go install golangci-lint")
-		if !cmd.Exec(a, "go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint", cmd.Dir(dirBuild)) {
+		if !runExec(a, "go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint", runDir(a, dirBuild)) {
 			return
 		}
-		a.Log("golangci-lint run --fix")
-		cmd.Exec(a, "golangci-lint run --fix", cmd.Dir(dirRoot))
-		a.Log("golangci-lint run --fix")
-		cmd.Exec(a, "golangci-lint run --fix", cmd.Dir(dirBuild))
+		runExec(a, "golangci-lint run --fix", runDir(a, dirRoot))
+		runExec(a, "golangci-lint run --fix", runDir(a, dirBuild))
 	},
 })

--- a/build/lint.go
+++ b/build/lint.go
@@ -10,10 +10,13 @@ var lint = goyek.Define(goyek.Task{
 	Name:  "lint",
 	Usage: "golangci-lint run --fix",
 	Action: func(a *goyek.A) {
+		a.Log("go install golangci-lint")
 		if !cmd.Exec(a, "go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint", cmd.Dir(dirBuild)) {
 			return
 		}
+		a.Log("golangci-lint run --fix")
 		cmd.Exec(a, "golangci-lint run --fix", cmd.Dir(dirRoot))
+		a.Log("golangci-lint run --fix")
 		cmd.Exec(a, "golangci-lint run --fix", cmd.Dir(dirBuild))
 	},
 })

--- a/build/main.go
+++ b/build/main.go
@@ -7,7 +7,6 @@ import (
 	"github.com/goyek/goyek/v3"
 
 	"github.com/goyek/x/boot"
-	"github.com/goyek/x/cmd"
 )
 
 // Directories used in repository.
@@ -22,16 +21,4 @@ func main() {
 	}
 	goyek.SetDefault(all)
 	boot.Main()
-}
-
-func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
-	a.Helper()
-	a.Log("Exec: ", cmdLine)
-	return cmd.Exec(a, cmdLine, opts...)
-}
-
-func runDir(a *goyek.A, s string) cmd.Option {
-	a.Helper()
-	a.Log("Work dir: ", s)
-	return cmd.Dir(s)
 }

--- a/build/main.go
+++ b/build/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/goyek/goyek/v3"
 
 	"github.com/goyek/x/boot"
+	"github.com/goyek/x/cmd"
 )
 
 // Directories used in repository.
@@ -21,4 +22,16 @@ func main() {
 	}
 	goyek.SetDefault(all)
 	boot.Main()
+}
+
+func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
+	a.Helper()
+	a.Log("Exec: ", cmdLine)
+	return cmd.Exec(a, cmdLine, opts...)
+}
+
+func runDir(a *goyek.A, s string) cmd.Option {
+	a.Helper()
+	a.Log("Work dir: ", s)
+	return cmd.Dir(s)
 }

--- a/build/mdlint.go
+++ b/build/mdlint.go
@@ -26,6 +26,8 @@ var mdlint = goyek.Define(goyek.Task{
 			a.Skip("no .md files")
 		}
 		dockerImage := "ghcr.io/igorshubovych/markdownlint-cli:v0.41.0"
-		cmd.Exec(a, "docker run --rm -v '"+curDir+":/workdir' "+dockerImage+" "+strings.Join(mdFiles, " "))
+		cmdLine := "docker run --rm -v '" + curDir + ":/workdir' " + dockerImage + " " + strings.Join(mdFiles, " ")
+		a.Log(cmdLine)
+		cmd.Exec(a, cmdLine)
 	},
 })

--- a/build/mdlint.go
+++ b/build/mdlint.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 
 	"github.com/goyek/goyek/v3"
-
-	"github.com/goyek/x/cmd"
 )
 
 var mdlint = goyek.Define(goyek.Task{
@@ -26,8 +24,7 @@ var mdlint = goyek.Define(goyek.Task{
 			a.Skip("no .md files")
 		}
 		dockerImage := "ghcr.io/igorshubovych/markdownlint-cli:v0.41.0"
-		cmdLine := "docker run --rm -v '" + curDir + ":/workdir' " + dockerImage + " " + strings.Join(mdFiles, " ")
-		a.Log(cmdLine)
-		cmd.Exec(a, cmdLine)
+		commandLine := "docker run --rm -v '" + curDir + ":/workdir' " + dockerImage + " " + strings.Join(mdFiles, " ")
+		runExec(a, commandLine)
 	},
 })

--- a/build/mod.go
+++ b/build/mod.go
@@ -2,17 +2,13 @@ package main
 
 import (
 	"github.com/goyek/goyek/v3"
-
-	"github.com/goyek/x/cmd"
 )
 
 var mod = goyek.Define(goyek.Task{
 	Name:  "mod",
 	Usage: "go mod tidy",
 	Action: func(a *goyek.A) {
-		a.Log("go mod tidy")
-		cmd.Exec(a, "go mod tidy", cmd.Dir(dirRoot))
-		a.Log("go mod tidy")
-		cmd.Exec(a, "go mod tidy", cmd.Dir(dirBuild))
+		runExec(a, "go mod tidy", runDir(a, dirRoot))
+		runExec(a, "go mod tidy", runDir(a, dirBuild))
 	},
 })

--- a/build/mod.go
+++ b/build/mod.go
@@ -10,7 +10,9 @@ var mod = goyek.Define(goyek.Task{
 	Name:  "mod",
 	Usage: "go mod tidy",
 	Action: func(a *goyek.A) {
+		a.Log("go mod tidy")
 		cmd.Exec(a, "go mod tidy", cmd.Dir(dirRoot))
+		a.Log("go mod tidy")
 		cmd.Exec(a, "go mod tidy", cmd.Dir(dirBuild))
 	},
 })

--- a/build/spell.go
+++ b/build/spell.go
@@ -12,6 +12,7 @@ var spell = goyek.Define(goyek.Task{
 	Name:  "spell",
 	Usage: "misspell",
 	Action: func(a *goyek.A) {
+		a.Log("go install misspell")
 		if !cmd.Exec(a, "go install github.com/client9/misspell/cmd/misspell", cmd.Dir(dirBuild)) {
 			return
 		}
@@ -19,6 +20,8 @@ var spell = goyek.Define(goyek.Task{
 		if len(mdFiles) == 0 {
 			a.Skip("no .md files")
 		}
-		cmd.Exec(a, "misspell -error -locale=US -w "+strings.Join(mdFiles, " "))
+		cmdLine := "misspell -error -locale=US -w " + strings.Join(mdFiles, " ")
+		a.Log(cmdLine)
+		cmd.Exec(a, cmdLine)
 	},
 })

--- a/build/spell.go
+++ b/build/spell.go
@@ -4,24 +4,19 @@ import (
 	"strings"
 
 	"github.com/goyek/goyek/v3"
-
-	"github.com/goyek/x/cmd"
 )
 
 var spell = goyek.Define(goyek.Task{
 	Name:  "spell",
 	Usage: "misspell",
 	Action: func(a *goyek.A) {
-		a.Log("go install misspell")
-		if !cmd.Exec(a, "go install github.com/client9/misspell/cmd/misspell", cmd.Dir(dirBuild)) {
+		if !runExec(a, "go install github.com/client9/misspell/cmd/misspell", runDir(a, dirBuild)) {
 			return
 		}
 		mdFiles := find(a, ".md")
 		if len(mdFiles) == 0 {
 			a.Skip("no .md files")
 		}
-		cmdLine := "misspell -error -locale=US -w " + strings.Join(mdFiles, " ")
-		a.Log(cmdLine)
-		cmd.Exec(a, cmdLine)
+		runExec(a, "misspell -error -locale=US -w "+strings.Join(mdFiles, " "))
 	},
 })

--- a/build/test.go
+++ b/build/test.go
@@ -10,9 +10,13 @@ var test = goyek.Define(goyek.Task{
 	Name:  "test",
 	Usage: "go test",
 	Action: func(a *goyek.A) {
-		if !cmd.Exec(a, "go test -race -covermode=atomic -coverprofile=coverage.out -coverpkg=./... ./...") {
+		cmdLine := "go test -race -covermode=atomic -coverprofile=coverage.out -coverpkg=./... ./..."
+		a.Log(cmdLine)
+		if !cmd.Exec(a, cmdLine) {
 			return
 		}
-		cmd.Exec(a, "go tool cover -html=coverage.out -o coverage.html")
+		cmdLine = "go tool cover -html=coverage.out -o coverage.html"
+		a.Log(cmdLine)
+		cmd.Exec(a, cmdLine)
 	},
 })

--- a/build/test.go
+++ b/build/test.go
@@ -2,21 +2,15 @@ package main
 
 import (
 	"github.com/goyek/goyek/v3"
-
-	"github.com/goyek/x/cmd"
 )
 
 var test = goyek.Define(goyek.Task{
 	Name:  "test",
 	Usage: "go test",
 	Action: func(a *goyek.A) {
-		cmdLine := "go test -race -covermode=atomic -coverprofile=coverage.out -coverpkg=./... ./..."
-		a.Log(cmdLine)
-		if !cmd.Exec(a, cmdLine) {
+		if !runExec(a, "go test -race -covermode=atomic -coverprofile=coverage.out -coverpkg=./... ./...") {
 			return
 		}
-		cmdLine = "go tool cover -html=coverage.out -o coverage.html"
-		a.Log(cmdLine)
-		cmd.Exec(a, cmdLine)
+		runExec(a, "go tool cover -html=coverage.out -o coverage.html")
 	},
 })

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/goyek/goyek/v3"
 	"github.com/mattn/go-shellwords"
@@ -37,7 +38,14 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 		opt(a, cmd)
 	}
 
-	a.Log("Exec: ", cmdLine)
+	parts := make([]string, 0, len(envs)+len(args))
+	for _, env := range envs {
+		split := strings.SplitN(env, "=", 2) //nolint:mnd
+		parts = append(parts, split[0]+"=[REDACTED]")
+	}
+	parts = append(parts, args...)
+	a.Log("Exec: ", strings.Join(parts, " "))
+
 	if err := cmd.Run(); err != nil {
 		a.Error(err)
 		return false

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/goyek/goyek/v3"
 	"github.com/mattn/go-shellwords"
@@ -38,14 +37,6 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 		opt(a, cmd)
 	}
 
-	parts := make([]string, 0, len(envs)+len(args))
-	for _, env := range envs {
-		split := strings.SplitN(env, "=", 2) //nolint:mnd // split into key and value
-		parts = append(parts, split[0]+"=[REDACTED]")
-	}
-	parts = append(parts, args...)
-	a.Log("Exec: ", strings.Join(parts, " "))
-
 	if err := cmd.Run(); err != nil {
 		a.Error(err)
 		return false
@@ -55,18 +46,14 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 
 // Dir is an option to set the working directory.
 func Dir(s string) Option {
-	return func(a *goyek.A, cmd *exec.Cmd) {
-		a.Helper()
-		a.Log("Work dir: ", s)
+	return func(_ *goyek.A, cmd *exec.Cmd) {
 		cmd.Dir = s
 	}
 }
 
 // Env is an option to set an environment variable.
 func Env(k, v string) Option {
-	return func(a *goyek.A, cmd *exec.Cmd) {
-		a.Helper()
-		a.Log("Env: ", k)
+	return func(_ *goyek.A, cmd *exec.Cmd) {
 		env := k + "=" + v
 		cmd.Env = append(cmd.Env, env)
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -40,7 +40,7 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 
 	parts := make([]string, 0, len(envs)+len(args))
 	for _, env := range envs {
-		split := strings.SplitN(env, "=", 2) //nolint:mnd
+		split := strings.SplitN(env, "=", 2) //nolint:mnd // split into key and value
 		parts = append(parts, split[0]+"=[REDACTED]")
 	}
 	parts = append(parts, args...)

--- a/cmd/security_test.go
+++ b/cmd/security_test.go
@@ -48,3 +48,40 @@ func TestEnvLogging(t *testing.T) {
 		t.Errorf("Env key was not logged: %s", got)
 	}
 }
+
+func TestExecLogging_Security(t *testing.T) {
+	sb := &strings.Builder{}
+
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = io.MultiWriter(in.Output, sb)
+			return next(in)
+		}
+	}
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			Exec(a, "SECRET=password echo hello")
+		},
+	})
+
+	oldFlow := goyek.DefaultFlow
+	defer func() { goyek.DefaultFlow = oldFlow }()
+	goyek.DefaultFlow = f
+	goyek.Use(mw)
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	if strings.Contains(got, "password") {
+		t.Errorf("Secret value in cmdLine was logged: %s", got)
+	}
+	if !strings.Contains(got, "SECRET=[REDACTED]") {
+		t.Errorf("Secret key was not redacted: %s", got)
+	}
+	if !strings.Contains(got, "echo hello") {
+		t.Errorf("Command was not logged: %s", got)
+	}
+}

--- a/cmd/security_test.go
+++ b/cmd/security_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/goyek/goyek/v3"
 )
 
-func TestEnvLogging(t *testing.T) {
+func TestLogging_Security(t *testing.T) {
 	sb := &strings.Builder{}
 
 	mw := func(next goyek.Runner) goyek.Runner {
@@ -25,44 +25,6 @@ func TestEnvLogging(t *testing.T) {
 		Name: "test",
 		Action: func(a *goyek.A) {
 			Env("SECRET_KEY", "very-sensitive-value")(a, &exec.Cmd{})
-		},
-	})
-
-	// Use the middleware to capture output
-	// goyek.Use is global, but Flow might have its own?
-	// Actually goyek.Use affects DefaultFlow.
-	// For a custom Flow, we might need another way or just use DefaultFlow.
-
-	oldFlow := goyek.DefaultFlow
-	defer func() { goyek.DefaultFlow = oldFlow }()
-	goyek.DefaultFlow = f
-	goyek.Use(mw)
-
-	_ = f.Execute(context.Background(), []string{"test"})
-
-	got := sb.String()
-	if strings.Contains(got, "very-sensitive-value") {
-		t.Errorf("Secret value was logged: %s", got)
-	}
-	if !strings.Contains(got, "SECRET_KEY") {
-		t.Errorf("Env key was not logged: %s", got)
-	}
-}
-
-func TestExecLogging_Security(t *testing.T) {
-	sb := &strings.Builder{}
-
-	mw := func(next goyek.Runner) goyek.Runner {
-		return func(in goyek.Input) goyek.Result {
-			in.Output = io.MultiWriter(in.Output, sb)
-			return next(in)
-		}
-	}
-
-	f := &goyek.Flow{}
-	f.Define(goyek.Task{
-		Name: "test",
-		Action: func(a *goyek.A) {
 			Exec(a, "SECRET=password echo hello")
 		},
 	})
@@ -75,13 +37,16 @@ func TestExecLogging_Security(t *testing.T) {
 	_ = f.Execute(context.Background(), []string{"test"})
 
 	got := sb.String()
+	if strings.Contains(got, "very-sensitive-value") {
+		t.Errorf("Secret value from Env was logged: %s", got)
+	}
+	if strings.Contains(got, "SECRET_KEY") {
+		t.Errorf("Env key was logged: %s", got)
+	}
 	if strings.Contains(got, "password") {
-		t.Errorf("Secret value in cmdLine was logged: %s", got)
+		t.Errorf("Secret value from Exec was logged: %s", got)
 	}
-	if !strings.Contains(got, "SECRET=[REDACTED]") {
-		t.Errorf("Secret key was not redacted: %s", got)
-	}
-	if !strings.Contains(got, "echo hello") {
-		t.Errorf("Command was not logged: %s", got)
+	if strings.Contains(got, "SECRET=") {
+		t.Errorf("Inline secret was logged: %s", got)
 	}
 }

--- a/graphviz/example_test.go
+++ b/graphviz/example_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/goyek/goyek/v3"
+
 	"github.com/goyek/x/graphviz"
 )
 

--- a/graphviz/graphviz.go
+++ b/graphviz/graphviz.go
@@ -14,8 +14,7 @@ type Option interface {
 	apply(*config)
 }
 
-type config struct {
-}
+type config struct{}
 
 // Draw visualizes a dependency graph with registered tasks in DOT format.
 func Draw(w io.Writer, flow *goyek.Flow, opts ...Option) error {

--- a/graphviz/graphviz_test.go
+++ b/graphviz/graphviz_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/goyek/goyek/v3"
+
 	"github.com/goyek/x/graphviz"
 )
 


### PR DESCRIPTION
Remove logging from `cmd.Exec`, `cmd.Dir`, and `cmd.Env` to prevent sensitive information leakage.