### PR TITLE
Limit captured output in otelgoyek span attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this library adheres to
 - Add `-graph` flag to `boot.Main` to output the task dependency graph
   in DOT format.
 - Add `otelgoyek.WithDisableOutput` option to disable output capture in traces.
+- Add `otelgoyek.WithOutputLimit` option to limit output capture in traces
+  to avoid memory exhaustion.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this library adheres to
   in DOT format.
 - Add `otelgoyek.WithDisableOutput` option to disable output capture in traces.
 - Add `otelgoyek.WithOutputLimit` option to limit output capture in traces
-  to avoid memory exhaustion.
+  to avoid memory exhaustion (the default is 1 MiB).
 
 ### Changed
 

--- a/otelgoyek/config.go
+++ b/otelgoyek/config.go
@@ -19,12 +19,14 @@ func (fn optionFunc) apply(cfg *config) {
 type config struct {
 	TracerProvider trace.TracerProvider
 	DisableOutput  bool
+	OutputLimit    int
 }
 
 func newConfig(opts []Option) *config {
 	c := &config{
 		TracerProvider: otel.GetTracerProvider(),
 		DisableOutput:  false,
+		OutputLimit:    1024 * 1024,
 	}
 	for _, opt := range opts {
 		opt.apply(c)
@@ -47,5 +49,13 @@ func WithTracerProvider(provider trace.TracerProvider) Option {
 func WithDisableOutput(disable bool) Option {
 	return optionFunc(func(cfg *config) {
 		cfg.DisableOutput = disable
+	})
+}
+
+// WithOutputLimit specifies the maximum number of bytes of output to capture in the span attributes.
+// The default is 1 MiB.
+func WithOutputLimit(limit int) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.OutputLimit = limit
 	})
 }

--- a/otelgoyek/config.go
+++ b/otelgoyek/config.go
@@ -26,7 +26,7 @@ func newConfig(opts []Option) *config {
 	c := &config{
 		TracerProvider: otel.GetTracerProvider(),
 		DisableOutput:  false,
-		OutputLimit:    1024 * 1024,
+		OutputLimit:    1024 * 1024, //nolint:mnd // 1 MiB
 	}
 	for _, opt := range opts {
 		opt.apply(c)

--- a/otelgoyek/otelgoyek.go
+++ b/otelgoyek/otelgoyek.go
@@ -22,7 +22,11 @@ const (
 func Middleware(opts ...Option) goyek.Middleware {
 	cfg := newConfig(opts)
 	tracer := cfg.TracerProvider.Tracer(instrumentationName, trace.WithInstrumentationVersion(instrumentationVersion))
-	r := runner{tracer, cfg.DisableOutput}
+	r := runner{
+		tracer:        tracer,
+		disableOutput: cfg.DisableOutput,
+		outputLimit:   cfg.OutputLimit,
+	}
 	return r.Middleware
 }
 
@@ -31,13 +35,18 @@ func Middleware(opts ...Option) goyek.Middleware {
 func ExecutorMiddleware(opts ...Option) goyek.ExecutorMiddleware {
 	cfg := newConfig(opts)
 	tracer := cfg.TracerProvider.Tracer(instrumentationName, trace.WithInstrumentationVersion(instrumentationVersion))
-	e := executor{tracer, cfg.DisableOutput}
+	e := executor{
+		tracer:        tracer,
+		disableOutput: cfg.DisableOutput,
+		outputLimit:   cfg.OutputLimit,
+	}
 	return e.Middleware
 }
 
 type executor struct {
 	tracer        trace.Tracer
 	disableOutput bool
+	outputLimit   int
 }
 
 func (e *executor) Middleware(next goyek.Executor) goyek.Executor {
@@ -54,7 +63,7 @@ func (e *executor) Middleware(next goyek.Executor) goyek.Executor {
 		var sb *strings.Builder
 		if !e.disableOutput {
 			sb = &strings.Builder{}
-			in.Output = io.MultiWriter(in.Output, sb)
+			in.Output = io.MultiWriter(in.Output, &limitWriter{sb: sb, limit: e.outputLimit})
 		}
 
 		err := next(in)
@@ -72,6 +81,7 @@ func (e *executor) Middleware(next goyek.Executor) goyek.Executor {
 type runner struct {
 	tracer        trace.Tracer
 	disableOutput bool
+	outputLimit   int
 }
 
 func (r *runner) Middleware(next goyek.Runner) goyek.Runner {
@@ -86,7 +96,7 @@ func (r *runner) Middleware(next goyek.Runner) goyek.Runner {
 		var sb *strings.Builder
 		if !r.disableOutput {
 			sb = &strings.Builder{}
-			in.Output = io.MultiWriter(in.Output, sb)
+			in.Output = io.MultiWriter(in.Output, &limitWriter{sb: sb, limit: r.outputLimit})
 		}
 
 		res := next(in)
@@ -112,4 +122,27 @@ func (r *runner) Middleware(next goyek.Runner) goyek.Runner {
 
 		return res
 	}
+}
+
+type limitWriter struct {
+	sb    *strings.Builder
+	limit int
+}
+
+func (w *limitWriter) Write(p []byte) (int, error) {
+	if w.limit <= 0 {
+		return len(p), nil
+	}
+	available := w.limit - w.sb.Len()
+	if available <= 0 {
+		return len(p), nil
+	}
+	if len(p) > available {
+		n, err := w.sb.Write(p[:available])
+		if err != nil {
+			return n, err
+		}
+		return len(p), nil
+	}
+	return w.sb.Write(p)
 }

--- a/otelgoyek/otelgoyek_test.go
+++ b/otelgoyek/otelgoyek_test.go
@@ -72,6 +72,88 @@ func TestExecutorMiddleware_WithDisableOutput(t *testing.T) {
 	}
 }
 
+func TestMiddleware_WithOutputLimit(t *testing.T) {
+	exp, tp := setupOTel()
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			fmt.Fprint(a.Output(), "1234567890")
+		},
+	})
+	f.Use(otelgoyek.Middleware(otelgoyek.WithTracerProvider(tp), otelgoyek.WithOutputLimit(5)))
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	spans := exp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+
+	var got string
+	found := false
+	for _, attr := range spans[0].Attributes {
+		if string(attr.Key) == "goyek.task.output" {
+			got = attr.Value.AsString()
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Error("goyek.task.output attribute not found")
+	}
+	if got != "12345" {
+		t.Errorf("expected truncated output '12345', got %q", got)
+	}
+}
+
+func TestExecutorMiddleware_WithOutputLimit(t *testing.T) {
+	exp, tp := setupOTel()
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			fmt.Fprint(a.Output(), "1234567890")
+		},
+	})
+	f.UseExecutor(otelgoyek.ExecutorMiddleware(otelgoyek.WithTracerProvider(tp), otelgoyek.WithOutputLimit(3)))
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	spans := exp.GetSpans()
+	var executeSpan *tracetest.SpanStub
+	for _, s := range spans {
+		if s.Name == "Execute" {
+			executeSpan = &s
+			break
+		}
+	}
+
+	if executeSpan == nil {
+		t.Fatal("Execute span not found")
+	}
+
+	var got string
+	found := false
+	for _, attr := range executeSpan.Attributes {
+		if string(attr.Key) == "goyek.flow.output" {
+			got = attr.Value.AsString()
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Error("goyek.flow.output attribute not found")
+	}
+	if got != "123" {
+		t.Errorf("expected truncated output '123', got %q", got)
+	}
+}
+
 func setupOTel() (*tracetest.InMemoryExporter, *trace.TracerProvider) {
 	exp := tracetest.NewInMemoryExporter()
 	tp := trace.NewTracerProvider(


### PR DESCRIPTION
The `otelgoyek` package previously captured task and flow output without any size limit, using an unbounded `strings.Builder`. This could lead to memory exhaustion (Denial of Service) if a task produced a very large amount of output. It could also cause issues with OpenTelemetry backends that reject spans with oversized attributes.

This change introduces a configurable output limit (defaulting to 1 MiB). A new `limitWriter` helper is used to ensure that only the specified amount of output is buffered for OpenTelemetry, while the actual task output remains unaffected.

Key changes:
- `otelgoyek/config.go`: Added `OutputLimit` and `WithOutputLimit`.
- `otelgoyek/otelgoyek.go`: Implemented `limitWriter` and integrated it into the middlewares.
- `otelgoyek/otelgoyek_test.go`: Added tests for output truncation.

---
*PR created automatically by Jules for task [3144938796080709255](https://jules.google.com/task/3144938796080709255) started by @pellared*