### PR TITLE
Fix sensitive info leakage in otelgoyek middleware during panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,6 @@ and this library adheres to
 
 - Remove logging from `cmd.Exec`, `cmd.Dir`, and `cmd.Env` to prevent sensitive
   information leakage.
-- Prevent recording panic value and stack trace in `otelgoyek.Middleware` when
-  `WithDisableOutput` is set to `true` to avoid sensitive data exposure.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this library adheres to
 
 - Remove logging from `cmd.Exec`, `cmd.Dir`, and `cmd.Env` to prevent sensitive
   information leakage.
+- Prevent recording panic value and stack trace in `otelgoyek.Middleware` when
+  `WithDisableOutput` is set to `true` to avoid sensitive data exposure.
 
 ### Removed
 

--- a/otelgoyek/otelgoyek.go
+++ b/otelgoyek/otelgoyek.go
@@ -110,7 +110,7 @@ func (r *runner) Middleware(next goyek.Runner) goyek.Runner {
 			span.SetStatus(codes.Error, "task failed: "+in.TaskName)
 		}
 
-		if res.PanicStack != nil {
+		if res.PanicStack != nil && !r.disableOutput {
 			if res.PanicValue != nil {
 				span.SetAttributes(attribute.String("goyek.task.panic.value", fmt.Sprint(res.PanicValue)))
 			} else {

--- a/otelgoyek/otelgoyek_test.go
+++ b/otelgoyek/otelgoyek_test.go
@@ -154,6 +154,45 @@ func TestExecutorMiddleware_WithOutputLimit(t *testing.T) {
 	}
 }
 
+func TestMiddleware_DisableOutput_Panic(t *testing.T) {
+	exp, tp := setupOTel()
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "panic",
+		Action: func(a *goyek.A) {
+			panic("sensitive info")
+		},
+	})
+	f.Use(otelgoyek.Middleware(
+		otelgoyek.WithTracerProvider(tp),
+		otelgoyek.WithDisableOutput(true),
+	))
+
+	_ = f.Execute(context.Background(), []string{"panic"})
+
+	spans := exp.GetSpans()
+	if len(spans) == 0 {
+		t.Fatal("no spans recorded")
+	}
+
+	for _, span := range spans {
+		if span.Name == "panic" {
+			for _, attr := range span.Attributes {
+				if string(attr.Key) == "goyek.task.panic.value" {
+					t.Errorf("panic value recorded even though output is disabled: %v", attr.Value.AsString())
+				}
+				if string(attr.Key) == "goyek.task.panic.stack" {
+					t.Errorf("panic stack recorded even though output is disabled")
+				}
+				if string(attr.Key) == "goyek.task.output" {
+					t.Errorf("output recorded even though output is disabled")
+				}
+			}
+		}
+	}
+}
+
 func setupOTel() (*tracetest.InMemoryExporter, *trace.TracerProvider) {
 	exp := tracetest.NewInMemoryExporter()
 	tp := trace.NewTracerProvider(

--- a/otelgoyek/otelgoyek_test.go
+++ b/otelgoyek/otelgoyek_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/goyek/x/otelgoyek"
 )
 
+const attrTaskOutput = "goyek.task.output"
+
 func TestMiddleware_WithDisableOutput(t *testing.T) {
 	exp, tp := setupOTel()
 
@@ -32,8 +34,8 @@ func TestMiddleware_WithDisableOutput(t *testing.T) {
 	}
 
 	for _, attr := range spans[0].Attributes {
-		if string(attr.Key) == "goyek.task.output" {
-			t.Errorf("found goyek.task.output attribute even though output capture is disabled: %v", attr.Value.AsString())
+		if string(attr.Key) == attrTaskOutput {
+			t.Errorf("found %s attribute even though output capture is disabled: %v", attrTaskOutput, attr.Value.AsString())
 		}
 	}
 }
@@ -94,7 +96,7 @@ func TestMiddleware_WithOutputLimit(t *testing.T) {
 	var got string
 	found := false
 	for _, attr := range spans[0].Attributes {
-		if string(attr.Key) == "goyek.task.output" {
+		if string(attr.Key) == attrTaskOutput {
 			got = attr.Value.AsString()
 			found = true
 			break
@@ -102,7 +104,7 @@ func TestMiddleware_WithOutputLimit(t *testing.T) {
 	}
 
 	if !found {
-		t.Error("goyek.task.output attribute not found")
+		t.Errorf("%s attribute not found", attrTaskOutput)
 	}
 	if got != "12345" {
 		t.Errorf("expected truncated output '12345', got %q", got)
@@ -160,7 +162,7 @@ func TestMiddleware_DisableOutput_Panic(t *testing.T) {
 	f := &goyek.Flow{}
 	f.Define(goyek.Task{
 		Name: "panic",
-		Action: func(a *goyek.A) {
+		Action: func(_ *goyek.A) {
 			panic("sensitive info")
 		},
 	})
@@ -185,7 +187,7 @@ func TestMiddleware_DisableOutput_Panic(t *testing.T) {
 				if string(attr.Key) == "goyek.task.panic.stack" {
 					t.Errorf("panic stack recorded even though output is disabled")
 				}
-				if string(attr.Key) == "goyek.task.output" {
+				if string(attr.Key) == attrTaskOutput {
 					t.Errorf("output recorded even though output is disabled")
 				}
 			}


### PR DESCRIPTION
This PR fixes a security issue in the `otelgoyek` middleware where sensitive information from panics (value and stack trace) was being recorded in OpenTelemetry span attributes even when `WithDisableOutput(true)` was configured.

I have:
1. Modified `otelgoyek/otelgoyek.go` to check `r.disableOutput` before recording panic info.
2. Added a regression test `TestMiddleware_DisableOutput_Panic` in `otelgoyek/otelgoyek_test.go`.
3. Updated `CHANGELOG.md` to reflect this change.
4. Verified that all tests pass.

---
*PR created automatically by Jules for task [12648605001480280979](https://jules.google.com/task/12648605001480280979) started by @pellared*