### PR TITLE
Fix data race in otelgoyek output capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this library adheres to
 - Remove logging from `cmd.Exec`, `cmd.Dir`, and `cmd.Env` to prevent sensitive
   information leakage.
 
+### Fixed
+
+- Fix data race in `otelgoyek` when capturing task or flow output.
+
 ### Removed
 
 - Drop support for Go 1.23.

--- a/otelgoyek/otelgoyek.go
+++ b/otelgoyek/otelgoyek.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/goyek/goyek/v3"
 	"go.opentelemetry.io/contrib/propagators/envcar"
@@ -147,11 +148,15 @@ func (r *runner) Middleware(next goyek.Runner) goyek.Runner {
 }
 
 type limitWriter struct {
+	mu    sync.Mutex
 	sb    *strings.Builder
 	limit int
 }
 
 func (w *limitWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	if w.limit <= 0 {
 		return len(p), nil
 	}

--- a/otelgoyek/otelgoyek_test.go
+++ b/otelgoyek/otelgoyek_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/goyek/goyek/v3"
@@ -371,4 +372,29 @@ func assertEnvParent(t *testing.T, span tracetest.SpanStub) {
 	if !span.Parent.IsRemote() {
 		t.Error("parent span context is not remote")
 	}
+}
+
+func TestMiddleware_OutputRace(t *testing.T) {
+	_, tp := setupOTel()
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "race",
+		Action: func(a *goyek.A) {
+			var wg sync.WaitGroup
+			for i := 0; i < 2; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for j := 0; j < 1000; j++ {
+						fmt.Fprint(a.Output(), "a")
+					}
+				}()
+			}
+			wg.Wait()
+		},
+	})
+	f.Use(otelgoyek.Middleware(otelgoyek.WithTracerProvider(tp)))
+
+	_ = f.Execute(context.Background(), []string{"race"})
 }

--- a/otelgoyek/otelgoyek_test.go
+++ b/otelgoyek/otelgoyek_test.go
@@ -17,9 +17,11 @@ import (
 	"github.com/goyek/x/otelgoyek"
 )
 
-const attrTaskOutput = "goyek.task.output"
-const traceparent = "00-0102030405060708090a0b0c0d0e0f10-0102030405060708-01"
-const spanNameExecute = "Execute"
+const (
+	attrTaskOutput  = "goyek.task.output"
+	traceparent     = "00-0102030405060708090a0b0c0d0e0f10-0102030405060708-01"
+	spanNameExecute = "Execute"
+)
 
 func TestMiddleware_WithDisableOutput(t *testing.T) {
 	exp, tp := setupOTel()
@@ -374,7 +376,7 @@ func assertEnvParent(t *testing.T, span tracetest.SpanStub) {
 	}
 }
 
-func TestMiddleware_OutputRace(t *testing.T) {
+func TestMiddleware_OutputRace(_ *testing.T) {
 	_, tp := setupOTel()
 
 	f := &goyek.Flow{}


### PR DESCRIPTION
Fixed a data race in the `otelgoyek` package that occurred when multiple goroutines wrote to a task's output concurrently while OpenTelemetry instrumentation was active.

Key changes:
- Added `sync.Mutex` to the internal `limitWriter` struct in `otelgoyek/otelgoyek.go`.
- Synchronized the `Write` method of `limitWriter` using the mutex.
- Added a new test case `TestMiddleware_OutputRace` in `otelgoyek/otelgoyek_test.go` that specifically targets this race condition.
- Updated `CHANGELOG.md` to reflect the fix.

The fix was verified by running `go test -race ./...`, which now passes consistently.

---
*PR created automatically by Jules for task [9147217016890251093](https://jules.google.com/task/9147217016890251093) started by @pellared*