### PR TITLE
Fix data race in otelgoyek output capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this library adheres to
 
 ## [Unreleased](https://github.com/goyek/x/compare/v0.4.0...HEAD)
 
+### Fixed
+
+- Fix data race in `otelgoyek` when capturing task or flow output.
+
 ### Added
 
 - Add `graphviz.Draw` function which visualizes a dependency graph

--- a/otelgoyek/otelgoyek.go
+++ b/otelgoyek/otelgoyek.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/goyek/goyek/v3"
 	"go.opentelemetry.io/contrib/propagators/envcar"
@@ -147,11 +148,14 @@ func (r *runner) Middleware(next goyek.Runner) goyek.Runner {
 }
 
 type limitWriter struct {
+	mu    sync.Mutex
 	sb    *strings.Builder
 	limit int
 }
 
 func (w *limitWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if w.limit <= 0 {
 		return len(p), nil
 	}

--- a/otelgoyek/otelgoyek.go
+++ b/otelgoyek/otelgoyek.go
@@ -75,16 +75,16 @@ func (e *executor) Middleware(next goyek.Executor) goyek.Executor {
 
 		in.Context = ctx
 
-		var sb *strings.Builder
+		var lw *limitWriter
 		if !e.disableOutput {
-			sb = &strings.Builder{}
-			in.Output = io.MultiWriter(in.Output, &limitWriter{sb: sb, limit: e.outputLimit})
+			lw = &limitWriter{sb: &strings.Builder{}, limit: e.outputLimit}
+			in.Output = io.MultiWriter(in.Output, lw)
 		}
 
 		err := next(in)
 
 		if !e.disableOutput {
-			span.SetAttributes(attribute.String("goyek.flow.output", sb.String()))
+			span.SetAttributes(attribute.String("goyek.flow.output", lw.String()))
 		}
 		if err != nil {
 			msg := err.Error()
@@ -116,16 +116,16 @@ func (r *runner) Middleware(next goyek.Runner) goyek.Runner {
 
 		in.Context = ctx
 
-		var sb *strings.Builder
+		var lw *limitWriter
 		if !r.disableOutput {
-			sb = &strings.Builder{}
-			in.Output = io.MultiWriter(in.Output, &limitWriter{sb: sb, limit: r.outputLimit})
+			lw = &limitWriter{sb: &strings.Builder{}, limit: r.outputLimit}
+			in.Output = io.MultiWriter(in.Output, lw)
 		}
 
 		res := next(in)
 
 		if !r.disableOutput {
-			span.SetAttributes(attribute.String("goyek.task.output", sb.String()))
+			span.SetAttributes(attribute.String("goyek.task.output", lw.String()))
 		}
 
 		span.SetAttributes(attribute.String("goyek.task.status", res.Status.String()))
@@ -171,6 +171,12 @@ func (w *limitWriter) Write(p []byte) (int, error) {
 		return len(p), nil
 	}
 	return w.sb.Write(p)
+}
+
+func (w *limitWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.sb.String()
 }
 
 func extractContextFromEnv(ctx context.Context, propagator propagation.TextMapPropagator) context.Context {

--- a/otelgoyek/otelgoyek_test.go
+++ b/otelgoyek/otelgoyek_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/goyek/x/otelgoyek"
 )
 
-const attrTaskOutput = "goyek.task.output"
-const traceparent = "00-0102030405060708090a0b0c0d0e0f10-0102030405060708-01"
-const spanNameExecute = "Execute"
+const (
+	attrTaskOutput  = "goyek.task.output"
+	traceparent     = "00-0102030405060708090a0b0c0d0e0f10-0102030405060708-01"
+	spanNameExecute = "Execute"
+)
 
 func TestMiddleware_WithDisableOutput(t *testing.T) {
 	exp, tp := setupOTel()

--- a/otelgoyek/race_test.go
+++ b/otelgoyek/race_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestLimitWriter_Race(t *testing.T) {
+func TestLimitWriter_Race(_ *testing.T) {
 	lw := &limitWriter{
 		sb:    &strings.Builder{},
 		limit: 10000,
@@ -19,7 +19,7 @@ func TestLimitWriter_Race(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 			for j := 0; j < 100; j++ {
-				_, _ = lw.Write([]byte(fmt.Sprintf("goroutine %d, line %d\n", id, j)))
+				_, _ = fmt.Fprintf(lw, "goroutine %d, line %d\n", id, j)
 			}
 		}(i)
 	}

--- a/otelgoyek/race_test.go
+++ b/otelgoyek/race_test.go
@@ -1,0 +1,27 @@
+package otelgoyek
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestLimitWriter_Race(t *testing.T) {
+	lw := &limitWriter{
+		sb:    &strings.Builder{},
+		limit: 10000,
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_, _ = lw.Write([]byte(fmt.Sprintf("goroutine %d, line %d\n", id, j)))
+			}
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Fixed a data race in the `otelgoyek` middleware's `limitWriter` by adding a `sync.Mutex` to synchronize concurrent writes to the captured output buffer. This ensures that the instrumentation is thread-safe even when tasks execute concurrent goroutines that write to their output.

Summary of changes:
- Modified `otelgoyek/otelgoyek.go` to add `sync.Mutex` to `limitWriter` and use it in `Write`.
- Added `otelgoyek/race_test.go` as a regression test to verify thread-safety under concurrent write pressure.
- Updated `CHANGELOG.md` to document the fix.

---
*PR created automatically by Jules for task [18180704943508522608](https://jules.google.com/task/18180704943508522608) started by @pellared*