### PR TITLE
Make output capture thread-safe in otelgoyek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this library adheres to
 
 ### Added
 
-- Add thread-safe `limitWriter` in `otelgoyek` to prevent data races when
-  capturing output.
 - Add `graphviz.Draw` function which visualizes a dependency graph
   with registered tasks.
 - Add `-graph` flag to `boot.Main` to output the task dependency graph
@@ -30,6 +28,11 @@ and this library adheres to
 
 - Remove logging from `cmd.Exec`, `cmd.Dir`, and `cmd.Env` to prevent sensitive
   information leakage.
+
+### Fixed
+
+- Fix races in `otelgoyek` when task output is written from multiple
+  goroutines.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this library adheres to
 
 ### Added
 
+- Add thread-safe `limitWriter` in `otelgoyek` to prevent data races when
+  capturing output.
 - Add `graphviz.Draw` function which visualizes a dependency graph
   with registered tasks.
 - Add `-graph` flag to `boot.Main` to output the task dependency graph

--- a/otelgoyek/otelgoyek.go
+++ b/otelgoyek/otelgoyek.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/goyek/goyek/v3"
 	"go.opentelemetry.io/contrib/propagators/envcar"
@@ -74,16 +75,16 @@ func (e *executor) Middleware(next goyek.Executor) goyek.Executor {
 
 		in.Context = ctx
 
-		var sb *strings.Builder
+		var lw *limitWriter
 		if !e.disableOutput {
-			sb = &strings.Builder{}
-			in.Output = io.MultiWriter(in.Output, &limitWriter{sb: sb, limit: e.outputLimit})
+			lw = &limitWriter{limit: e.outputLimit}
+			in.Output = io.MultiWriter(in.Output, lw)
 		}
 
 		err := next(in)
 
 		if !e.disableOutput {
-			span.SetAttributes(attribute.String("goyek.flow.output", sb.String()))
+			span.SetAttributes(attribute.String("goyek.flow.output", lw.String()))
 		}
 		if err != nil {
 			msg := err.Error()
@@ -115,16 +116,16 @@ func (r *runner) Middleware(next goyek.Runner) goyek.Runner {
 
 		in.Context = ctx
 
-		var sb *strings.Builder
+		var lw *limitWriter
 		if !r.disableOutput {
-			sb = &strings.Builder{}
-			in.Output = io.MultiWriter(in.Output, &limitWriter{sb: sb, limit: r.outputLimit})
+			lw = &limitWriter{limit: r.outputLimit}
+			in.Output = io.MultiWriter(in.Output, lw)
 		}
 
 		res := next(in)
 
 		if !r.disableOutput {
-			span.SetAttributes(attribute.String("goyek.task.output", sb.String()))
+			span.SetAttributes(attribute.String("goyek.task.output", lw.String()))
 		}
 
 		span.SetAttributes(attribute.String("goyek.task.status", res.Status.String()))
@@ -147,11 +148,14 @@ func (r *runner) Middleware(next goyek.Runner) goyek.Runner {
 }
 
 type limitWriter struct {
-	sb    *strings.Builder
+	mu    sync.Mutex
+	sb    strings.Builder
 	limit int
 }
 
 func (w *limitWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if w.limit <= 0 {
 		return len(p), nil
 	}
@@ -167,6 +171,12 @@ func (w *limitWriter) Write(p []byte) (int, error) {
 		return len(p), nil
 	}
 	return w.sb.Write(p)
+}
+
+func (w *limitWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.sb.String()
 }
 
 func extractContextFromEnv(ctx context.Context, propagator propagation.TextMapPropagator) context.Context {


### PR DESCRIPTION
I have fixed a data race in the `otelgoyek` package that occurred when capturing task or flow output in OpenTelemetry span attributes.

The `limitWriter` struct was using a `strings.Builder` without synchronization, leading to race conditions when tasks performed concurrent writes to their output.

Changes:
- Added `sync.Mutex` to `limitWriter` in `otelgoyek/otelgoyek.go`.
- Changed `limitWriter.sb` from a pointer to a value to encapsulate it.
- Implemented thread-safe `Write` and `String` methods for `limitWriter`.
- Updated `Middleware` and `ExecutorMiddleware` to use the thread-safe `limitWriter` correctly.
- Updated `CHANGELOG.md`.

Verified the fix using a reproduction test with `go test -race`.

---
*PR created automatically by Jules for task [12816169429727195886](https://jules.google.com/task/12816169429727195886) started by @pellared*