### PR TITLE
Fix data race in otelgoyek output capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this library adheres to
 
 ## [Unreleased](https://github.com/goyek/x/compare/v0.4.0...HEAD)
 
+### Fixed
+
+- Fix data race in `otelgoyek.Middleware` and `otelgoyek.ExecutorMiddleware` when
+  capturing task output.
+
 ### Added
 
 - Add `graphviz.Draw` function which visualizes a dependency graph

--- a/otelgoyek/otelgoyek.go
+++ b/otelgoyek/otelgoyek.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/goyek/goyek/v3"
 	"go.opentelemetry.io/contrib/propagators/envcar"
@@ -147,11 +148,14 @@ func (r *runner) Middleware(next goyek.Runner) goyek.Runner {
 }
 
 type limitWriter struct {
+	mu    sync.Mutex
 	sb    *strings.Builder
 	limit int
 }
 
 func (w *limitWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if w.limit <= 0 {
 		return len(p), nil
 	}

--- a/otelgoyek/race_test.go
+++ b/otelgoyek/race_test.go
@@ -1,0 +1,74 @@
+package otelgoyek_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+	"github.com/goyek/x/otelgoyek"
+)
+
+func TestMiddleware_OutputRace(t *testing.T) {
+	exp, tp := setupOTel()
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "race",
+		Action: func(a *goyek.A) {
+			var wg sync.WaitGroup
+			for i := 0; i < 10; i++ {
+				wg.Add(1)
+				go func(i int) {
+					defer wg.Done()
+					fmt.Fprintf(a.Output(), "message %d\n", i)
+				}(i)
+			}
+			wg.Wait()
+		},
+	})
+	f.Use(otelgoyek.Middleware(otelgoyek.WithTracerProvider(tp)))
+
+	_ = f.Execute(context.Background(), []string{"race"})
+
+	spans := exp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+}
+
+func TestExecutorMiddleware_OutputRace(t *testing.T) {
+	exp, tp := setupOTel()
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "race",
+		Action: func(a *goyek.A) {
+			var wg sync.WaitGroup
+			for i := 0; i < 10; i++ {
+				wg.Add(1)
+				go func(i int) {
+					defer wg.Done()
+					fmt.Fprintf(a.Output(), "message %d\n", i)
+				}(i)
+			}
+			wg.Wait()
+		},
+	})
+	f.UseExecutor(otelgoyek.ExecutorMiddleware(otelgoyek.WithTracerProvider(tp)))
+
+	_ = f.Execute(context.Background(), []string{"race"})
+
+	spans := exp.GetSpans()
+	found := false
+	for _, s := range spans {
+		if s.Name == "Execute" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("Execute span not found")
+	}
+}


### PR DESCRIPTION
This PR fixes a data race in the `otelgoyek` package where concurrent writes to task output could lead to race conditions when capturing output for OpenTelemetry spans. A `sync.Mutex` was added to `limitWriter` to ensure thread-safe access to the underlying `strings.Builder`.

Regression tests were added to `otelgoyek/race_test.go` to verify the fix and ensure no regressions in both `Middleware` and `ExecutorMiddleware`.

---
*PR created automatically by Jules for task [14198214405127593207](https://jules.google.com/task/14198214405127593207) started by @pellared*