### PR TITLE
Add environment control options to cmd package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this library adheres to
   `otelgoyek` spans.
 - Add `otelgoyek.WithPropagator` option to configure context extraction from
   environment variables.
+- Add `cmd.ClearEnv` option to prevent environment inheritance in `cmd.Exec`.
+- Add `cmd.UnsetEnv` option to remove a specific environment variable in `cmd.Exec`.
 
 ### Changed
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/goyek/goyek/v3"
 	"github.com/mattn/go-shellwords"
@@ -56,6 +57,31 @@ func Env(k, v string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {
 		env := k + "=" + v
 		cmd.Env = append(cmd.Env, env)
+	}
+}
+
+// UnsetEnv is an option to unset an environment variable.
+func UnsetEnv(key string) Option {
+	return func(_ *goyek.A, cmd *exec.Cmd) {
+		prefix := key + "="
+		env := cmd.Env
+		if env == nil {
+			env = os.Environ()
+		}
+		newEnv := make([]string, 0, len(env))
+		for _, e := range env {
+			if !strings.HasPrefix(e, prefix) {
+				newEnv = append(newEnv, e)
+			}
+		}
+		cmd.Env = newEnv
+	}
+}
+
+// ClearEnv is an option to clear the environment variables.
+func ClearEnv() Option {
+	return func(_ *goyek.A, cmd *exec.Cmd) {
+		cmd.Env = []string{}
 	}
 }
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestUnsetEnv(t *testing.T) {
+	a := &goyek.A{}
+	cmd := &exec.Cmd{
+		Env: []string{"FOO=bar", "BAZ=qux"},
+	}
+
+	UnsetEnv("FOO")(a, cmd)
+
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "FOO=") {
+			t.Errorf("expected FOO to be unset, but got: %s", e)
+		}
+	}
+	found := false
+	for _, e := range cmd.Env {
+		if e == "BAZ=qux" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected BAZ=qux to be preserved")
+	}
+}
+
+func TestUnsetEnv_Nil(t *testing.T) {
+	t.Setenv("GOYEK_TEST_VAR", "present")
+	a := &goyek.A{}
+	cmd := &exec.Cmd{
+		Env: nil,
+	}
+
+	UnsetEnv("GOYEK_TEST_VAR")(a, cmd)
+
+	if cmd.Env == nil {
+		t.Error("expected Env not to be nil")
+	}
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "GOYEK_TEST_VAR=") {
+			t.Errorf("expected GOYEK_TEST_VAR to be unset, but got: %s", e)
+		}
+	}
+}
+
+func TestClearEnv(t *testing.T) {
+	a := &goyek.A{}
+	cmd := &exec.Cmd{
+		Env: []string{"FOO=bar", "BAZ=qux"},
+	}
+
+	ClearEnv()(a, cmd)
+
+	if cmd.Env == nil || len(cmd.Env) != 0 {
+		t.Errorf("expected empty env, but got: %v", cmd.Env)
+	}
+}
+
+func TestExec_ClearEnv(t *testing.T) {
+	t.Setenv("GOYEK_TEST_VAR", "present")
+
+	f := &goyek.Flow{}
+	var output strings.Builder
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			Exec(a, "env", ClearEnv(), Stdout(&output))
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := output.String()
+	if strings.Contains(got, "GOYEK_TEST_VAR=present") {
+		t.Error("GOYEK_TEST_VAR should not be present in a cleared environment")
+	}
+}
+
+func TestExec_ClearEnv_WithEnv(t *testing.T) {
+	t.Setenv("GOYEK_HIDDEN", "secret")
+	f := &goyek.Flow{}
+	var output strings.Builder
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			Exec(a, "env", ClearEnv(), Env("NEW_VAR", "value"), Stdout(&output))
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := output.String()
+	if !strings.Contains(got, "NEW_VAR=value") {
+		t.Error("NEW_VAR=value should be present")
+	}
+
+	if strings.Contains(got, "GOYEK_HIDDEN=") {
+		t.Error("GOYEK_HIDDEN should not be present")
+	}
+}
+
+func TestExec_UnsetEnv(t *testing.T) {
+	t.Setenv("GOYEK_TEST_VAR", "present")
+	t.Setenv("ANOTHER_VAR", "stay")
+
+	f := &goyek.Flow{}
+	var output strings.Builder
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			Exec(a, "env", UnsetEnv("GOYEK_TEST_VAR"), Stdout(&output))
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := output.String()
+	if strings.Contains(got, "GOYEK_TEST_VAR=present") {
+		t.Error("GOYEK_TEST_VAR should have been unset")
+	}
+	if !strings.Contains(got, "ANOTHER_VAR=stay") {
+		t.Error("ANOTHER_VAR should still be present")
+	}
+}


### PR DESCRIPTION
Added `ClearEnv` and `UnsetEnv` options to the `cmd` package to allow for better control over the environment variables passed to subprocesses, improving security by following the principle of least privilege.

---
*PR created automatically by Jules for task [2167705107329793928](https://jules.google.com/task/2167705107329793928) started by @pellared*