### PR TITLE
otelgoyek: truncate panic details and flow error messages in spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,6 @@ and this library adheres to
 
 - Fix races in `otelgoyek` when task output is written from multiple
   goroutines.
-- Truncate panic values, panic stack traces, and flow error messages in `otelgoyek`
-  according to `WithOutputLimit`.
-- Set OpenTelemetry span status to error when a task panics in `otelgoyek`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this library adheres to
 
 - Fix races in `otelgoyek` when task output is written from multiple
   goroutines.
+- Truncate panic values, panic stack traces, and flow error messages in `otelgoyek`
+  according to `WithOutputLimit`.
+- Set OpenTelemetry span status to error when a task panics in `otelgoyek`.
 
 ### Removed
 

--- a/otelgoyek/otelgoyek.go
+++ b/otelgoyek/otelgoyek.go
@@ -90,6 +90,8 @@ func (e *executor) Middleware(next goyek.Executor) goyek.Executor {
 			msg := err.Error()
 			if e.disableOutput {
 				msg = "flow execution failed"
+			} else if e.outputLimit > 0 && len(msg) > e.outputLimit {
+				msg = msg[:e.outputLimit]
 			}
 			span.SetStatus(codes.Error, msg)
 		}
@@ -135,12 +137,20 @@ func (r *runner) Middleware(next goyek.Runner) goyek.Runner {
 
 		if res.PanicStack != nil && !r.disableOutput {
 			if res.PanicValue != nil {
-				span.SetAttributes(attribute.String("goyek.task.panic.value", fmt.Sprint(res.PanicValue)))
+				val := fmt.Sprint(res.PanicValue)
+				if r.outputLimit > 0 && len(val) > r.outputLimit {
+					val = val[:r.outputLimit]
+				}
+				span.SetAttributes(attribute.String("goyek.task.panic.value", val))
 			} else {
 				span.SetAttributes(attribute.String("goyek.task.panic.value", "panic(nil) or runtime.Goexit() called"))
 			}
 
-			span.SetAttributes(attribute.String("goyek.task.panic.stack", string(res.PanicStack)))
+			stack := string(res.PanicStack)
+			if r.outputLimit > 0 && len(stack) > r.outputLimit {
+				stack = stack[:r.outputLimit]
+			}
+			span.SetAttributes(attribute.String("goyek.task.panic.stack", stack))
 		}
 
 		return res

--- a/otelgoyek/otelgoyek_test.go
+++ b/otelgoyek/otelgoyek_test.go
@@ -46,6 +46,123 @@ func TestMiddleware_WithDisableOutput(t *testing.T) {
 	}
 }
 
+func TestMiddleware_PanicStatus(t *testing.T) {
+	exp, tp := setupOTel()
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "panic",
+		Action: func(_ *goyek.A) {
+			panic("something went wrong")
+		},
+	})
+	f.Use(otelgoyek.Middleware(otelgoyek.WithTracerProvider(tp)))
+
+	_ = f.Execute(context.Background(), []string{"panic"})
+
+	spans := exp.GetSpans()
+	if len(spans) == 0 {
+		t.Fatal("no spans recorded")
+	}
+
+	for _, span := range spans {
+		if span.Name == "panic" {
+			if span.Status.Code != codes.Error {
+				t.Errorf("expected span status Error for panicking task, got %v", span.Status.Code)
+			}
+		}
+	}
+}
+
+func TestMiddleware_PanicTruncation(t *testing.T) {
+	exp, tp := setupOTel()
+
+	limit := 10
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "panic",
+		Action: func(_ *goyek.A) {
+			panic("1234567890ABCDE")
+		},
+	})
+	f.Use(otelgoyek.Middleware(otelgoyek.WithTracerProvider(tp), otelgoyek.WithOutputLimit(limit)))
+
+	_ = f.Execute(context.Background(), []string{"panic"})
+
+	spans := exp.GetSpans()
+	var taskSpan *tracetest.SpanStub
+	for _, s := range spans {
+		if s.Name == "panic" {
+			taskSpan = &s
+			break
+		}
+	}
+
+	if taskSpan == nil {
+		t.Fatal("task span not found")
+	}
+
+	for _, attr := range taskSpan.Attributes {
+		if string(attr.Key) == "goyek.task.panic.value" {
+			got := attr.Value.AsString()
+			if len(got) > limit {
+				t.Errorf("panic value not truncated: got length %d, limit %d", len(got), limit)
+			}
+			if got != "1234567890" {
+				t.Errorf("expected truncated panic value '1234567890', got %q", got)
+			}
+		}
+		if string(attr.Key) == "goyek.task.panic.stack" {
+			got := attr.Value.AsString()
+			if len(got) > limit {
+				t.Errorf("panic stack not truncated: got length %d, limit %d", len(got), limit)
+			}
+		}
+	}
+}
+
+func TestExecutorMiddleware_ErrorTruncation(t *testing.T) {
+	exp, tp := setupOTel()
+
+	limit := 5
+	mw := otelgoyek.ExecutorMiddleware(
+		otelgoyek.WithTracerProvider(tp),
+		otelgoyek.WithOutputLimit(limit),
+	)
+
+	next := func(_ goyek.ExecuteInput) error {
+		return fmt.Errorf("1234567890")
+	}
+
+	executor := mw(next)
+
+	_ = executor(goyek.ExecuteInput{
+		Context: context.Background(),
+		Tasks:   []string{"test"},
+	})
+
+	spans := exp.GetSpans()
+	var executeSpan *tracetest.SpanStub
+	for _, s := range spans {
+		if s.Name == spanNameExecute {
+			executeSpan = &s
+			break
+		}
+	}
+
+	if executeSpan == nil {
+		t.Fatal("Execute span not found")
+	}
+
+	got := executeSpan.Status.Description
+	if len(got) > limit {
+		t.Errorf("error status description not truncated: got length %d, limit %d", len(got), limit)
+	}
+	if got != "12345" {
+		t.Errorf("expected truncated error message '12345', got %q", got)
+	}
+}
+
 func TestExecutorMiddleware_WithDisableOutput(t *testing.T) {
 	exp, tp := setupOTel()
 

--- a/otelgoyek/otelgoyek_test.go
+++ b/otelgoyek/otelgoyek_test.go
@@ -19,20 +19,22 @@ import (
 const attrTaskOutput = "goyek.task.output"
 const traceparent = "00-0102030405060708090a0b0c0d0e0f10-0102030405060708-01"
 const spanNameExecute = "Execute"
+const taskNameTest = "test"
+const taskNamePanic = "panic"
 
 func TestMiddleware_WithDisableOutput(t *testing.T) {
 	exp, tp := setupOTel()
 
 	f := &goyek.Flow{}
 	f.Define(goyek.Task{
-		Name: "test",
+		Name: taskNameTest,
 		Action: func(a *goyek.A) {
 			fmt.Fprint(a.Output(), "secret message")
 		},
 	})
 	f.Use(otelgoyek.Middleware(otelgoyek.WithTracerProvider(tp), otelgoyek.WithDisableOutput(true)))
 
-	_ = f.Execute(context.Background(), []string{"test"})
+	_ = f.Execute(context.Background(), []string{taskNameTest})
 
 	spans := exp.GetSpans()
 	if len(spans) != 1 {
@@ -51,14 +53,14 @@ func TestMiddleware_PanicStatus(t *testing.T) {
 
 	f := &goyek.Flow{}
 	f.Define(goyek.Task{
-		Name: "panic",
+		Name: taskNamePanic,
 		Action: func(_ *goyek.A) {
 			panic("something went wrong")
 		},
 	})
 	f.Use(otelgoyek.Middleware(otelgoyek.WithTracerProvider(tp)))
 
-	_ = f.Execute(context.Background(), []string{"panic"})
+	_ = f.Execute(context.Background(), []string{taskNamePanic})
 
 	spans := exp.GetSpans()
 	if len(spans) == 0 {
@@ -66,7 +68,7 @@ func TestMiddleware_PanicStatus(t *testing.T) {
 	}
 
 	for _, span := range spans {
-		if span.Name == "panic" {
+		if span.Name == taskNamePanic {
 			if span.Status.Code != codes.Error {
 				t.Errorf("expected span status Error for panicking task, got %v", span.Status.Code)
 			}
@@ -80,19 +82,19 @@ func TestMiddleware_PanicTruncation(t *testing.T) {
 	limit := 10
 	f := &goyek.Flow{}
 	f.Define(goyek.Task{
-		Name: "panic",
+		Name: taskNamePanic,
 		Action: func(_ *goyek.A) {
 			panic("1234567890ABCDE")
 		},
 	})
 	f.Use(otelgoyek.Middleware(otelgoyek.WithTracerProvider(tp), otelgoyek.WithOutputLimit(limit)))
 
-	_ = f.Execute(context.Background(), []string{"panic"})
+	_ = f.Execute(context.Background(), []string{taskNamePanic})
 
 	spans := exp.GetSpans()
 	var taskSpan *tracetest.SpanStub
 	for _, s := range spans {
-		if s.Name == "panic" {
+		if s.Name == taskNamePanic {
 			taskSpan = &s
 			break
 		}
@@ -138,7 +140,7 @@ func TestExecutorMiddleware_ErrorTruncation(t *testing.T) {
 
 	_ = executor(goyek.ExecuteInput{
 		Context: context.Background(),
-		Tasks:   []string{"test"},
+		Tasks:   []string{taskNameTest},
 	})
 
 	spans := exp.GetSpans()
@@ -168,14 +170,14 @@ func TestExecutorMiddleware_WithDisableOutput(t *testing.T) {
 
 	f := &goyek.Flow{}
 	f.Define(goyek.Task{
-		Name: "test",
+		Name: taskNameTest,
 		Action: func(a *goyek.A) {
 			fmt.Fprint(a.Output(), "secret flow message")
 		},
 	})
 	f.UseExecutor(otelgoyek.ExecutorMiddleware(otelgoyek.WithTracerProvider(tp), otelgoyek.WithDisableOutput(true)))
 
-	_ = f.Execute(context.Background(), []string{"test"})
+	_ = f.Execute(context.Background(), []string{taskNameTest})
 
 	spans := exp.GetSpans()
 	var executeSpan *tracetest.SpanStub
@@ -204,13 +206,13 @@ func TestMiddleware_ExtractsTraceContextFromEnvironment(t *testing.T) {
 
 	f := &goyek.Flow{}
 	f.Define(goyek.Task{
-		Name: "test",
+		Name: taskNameTest,
 		Action: func(_ *goyek.A) {
 		},
 	})
 	f.Use(otelgoyek.Middleware(otelgoyek.WithTracerProvider(tp)))
 
-	_ = f.Execute(context.Background(), []string{"test"})
+	_ = f.Execute(context.Background(), []string{taskNameTest})
 
 	spans := exp.GetSpans()
 	if len(spans) != 1 {
@@ -226,7 +228,7 @@ func TestMiddleware_WithPropagator(t *testing.T) {
 
 	f := &goyek.Flow{}
 	f.Define(goyek.Task{
-		Name: "test",
+		Name: taskNameTest,
 		Action: func(_ *goyek.A) {
 		},
 	})
@@ -235,7 +237,7 @@ func TestMiddleware_WithPropagator(t *testing.T) {
 		otelgoyek.WithPropagator(propagation.TraceContext{}),
 	))
 
-	_ = f.Execute(context.Background(), []string{"test"})
+	_ = f.Execute(context.Background(), []string{taskNameTest})
 
 	spans := exp.GetSpans()
 	if len(spans) != 1 {
@@ -251,13 +253,13 @@ func TestExecutorMiddleware_ExtractsTraceContextFromEnvironment(t *testing.T) {
 
 	f := &goyek.Flow{}
 	f.Define(goyek.Task{
-		Name: "test",
+		Name: taskNameTest,
 		Action: func(_ *goyek.A) {
 		},
 	})
 	f.UseExecutor(otelgoyek.ExecutorMiddleware(otelgoyek.WithTracerProvider(tp)))
 
-	_ = f.Execute(context.Background(), []string{"test"})
+	_ = f.Execute(context.Background(), []string{taskNameTest})
 
 	spans := exp.GetSpans()
 	if len(spans) != 1 {
@@ -273,7 +275,7 @@ func TestExecutorMiddleware_WithPropagator(t *testing.T) {
 
 	f := &goyek.Flow{}
 	f.Define(goyek.Task{
-		Name: "test",
+		Name: taskNameTest,
 		Action: func(_ *goyek.A) {
 		},
 	})
@@ -282,7 +284,7 @@ func TestExecutorMiddleware_WithPropagator(t *testing.T) {
 		otelgoyek.WithPropagator(propagation.TraceContext{}),
 	))
 
-	_ = f.Execute(context.Background(), []string{"test"})
+	_ = f.Execute(context.Background(), []string{taskNameTest})
 
 	spans := exp.GetSpans()
 	if len(spans) != 1 {
@@ -296,14 +298,14 @@ func TestMiddleware_WithOutputLimit(t *testing.T) {
 
 	f := &goyek.Flow{}
 	f.Define(goyek.Task{
-		Name: "test",
+		Name: taskNameTest,
 		Action: func(a *goyek.A) {
 			fmt.Fprint(a.Output(), "1234567890")
 		},
 	})
 	f.Use(otelgoyek.Middleware(otelgoyek.WithTracerProvider(tp), otelgoyek.WithOutputLimit(5)))
 
-	_ = f.Execute(context.Background(), []string{"test"})
+	_ = f.Execute(context.Background(), []string{taskNameTest})
 
 	spans := exp.GetSpans()
 	if len(spans) != 1 {
@@ -333,14 +335,14 @@ func TestExecutorMiddleware_WithOutputLimit(t *testing.T) {
 
 	f := &goyek.Flow{}
 	f.Define(goyek.Task{
-		Name: "test",
+		Name: taskNameTest,
 		Action: func(a *goyek.A) {
 			fmt.Fprint(a.Output(), "1234567890")
 		},
 	})
 	f.UseExecutor(otelgoyek.ExecutorMiddleware(otelgoyek.WithTracerProvider(tp), otelgoyek.WithOutputLimit(3)))
 
-	_ = f.Execute(context.Background(), []string{"test"})
+	_ = f.Execute(context.Background(), []string{taskNameTest})
 
 	spans := exp.GetSpans()
 	var executeSpan *tracetest.SpanStub
@@ -391,7 +393,7 @@ func TestExecutorMiddleware_WithDisableOutput_StatusLeak(t *testing.T) {
 
 	_ = executor(goyek.ExecuteInput{
 		Context: context.Background(),
-		Tasks:   []string{"test"},
+		Tasks:   []string{taskNameTest},
 	})
 
 	spans := exp.GetSpans()
@@ -421,7 +423,7 @@ func TestMiddleware_DisableOutput_Panic(t *testing.T) {
 
 	f := &goyek.Flow{}
 	f.Define(goyek.Task{
-		Name: "panic",
+		Name: taskNamePanic,
 		Action: func(_ *goyek.A) {
 			panic("sensitive info")
 		},
@@ -431,7 +433,7 @@ func TestMiddleware_DisableOutput_Panic(t *testing.T) {
 		otelgoyek.WithDisableOutput(true),
 	))
 
-	_ = f.Execute(context.Background(), []string{"panic"})
+	_ = f.Execute(context.Background(), []string{taskNamePanic})
 
 	spans := exp.GetSpans()
 	if len(spans) == 0 {
@@ -439,7 +441,7 @@ func TestMiddleware_DisableOutput_Panic(t *testing.T) {
 	}
 
 	for _, span := range spans {
-		if span.Name == "panic" {
+		if span.Name == taskNamePanic {
 			for _, attr := range span.Attributes {
 				if string(attr.Key) == "goyek.task.panic.value" {
 					t.Errorf("panic value recorded even though output is disabled: %v", attr.Value.AsString())


### PR DESCRIPTION
This change enhances the security and robustness of the `otelgoyek` instrumentation by:
1. Truncating panic values, panic stack traces, and flow error messages in OpenTelemetry span attributes/status according to the `WithOutputLimit` option (defaulting to 1 MiB). This prevents potential memory exhaustion or oversized OTLP payloads and limits sensitive data exposure.
2. Ensuring that if a task panics, the corresponding OpenTelemetry span is correctly marked with an Error status.
3. Adding comprehensive regression tests in `otelgoyek_test.go` to verify these behaviors.

---
*PR created automatically by Jules for task [1693718486833454263](https://jules.google.com/task/1693718486833454263) started by @pellared*