### PR TITLE
Fix cmd.Env inheritance and improve cmd.Exec precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,15 @@ and this library adheres to
 
 - Remove logging from `cmd.Exec`, `cmd.Dir`, and `cmd.Env` to prevent sensitive
   information leakage.
+- Improve `cmd.Exec` to ensure environment variables from command line string
+  override those from options.
 
 ### Fixed
 
 - Fix races in `otelgoyek` when task output is written from multiple
   goroutines.
+- Fix `cmd.Env` to preserve environment inheritance when used on a command
+  with uninitialized environment.
 
 ### Removed
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -36,10 +36,10 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	cmd.Stdout = a.Output()
 	cmd.Stderr = a.Output()
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, envs...)
 	for _, opt := range opts {
 		opt(a, cmd)
 	}
+	cmd.Env = append(cmd.Env, envs...)
 
 	if err := cmd.Run(); err != nil {
 		a.Error(err)
@@ -58,6 +58,9 @@ func Dir(s string) Option {
 // Env is an option to set an environment variable.
 func Env(k, v string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {
+		if cmd.Env == nil {
+			cmd.Env = os.Environ()
+		}
 		env := k + "=" + v
 		cmd.Env = append(cmd.Env, env)
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -34,6 +34,26 @@ func TestUnsetEnv(t *testing.T) {
 	}
 }
 
+func TestEnv_Inheritance(t *testing.T) {
+	t.Setenv("PARENT_VAR", "parent-value")
+	a := &goyek.A{}
+	cmd := &exec.Cmd{} // Env is nil
+
+	Env("NEW_VAR", "new-value")(a, cmd)
+
+	foundParent := false
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "PARENT_VAR=") {
+			foundParent = true
+			break
+		}
+	}
+
+	if !foundParent {
+		t.Error("expected PARENT_VAR to be inherited when using Env option on a nil-Env Cmd")
+	}
+}
+
 func TestUnsetEnv_NoValue(t *testing.T) {
 	a := &goyek.A{}
 	cmd := &exec.Cmd{
@@ -131,6 +151,53 @@ func TestExec_ClearEnv_WithEnv(t *testing.T) {
 
 	if strings.Contains(got, "GOYEK_HIDDEN=") {
 		t.Error("GOYEK_HIDDEN should not be present")
+	}
+}
+
+func TestExec_ClearEnv_WithInlineEnv(t *testing.T) {
+	t.Setenv("GOYEK_HIDDEN", "secret")
+	f := &goyek.Flow{}
+	var output strings.Builder
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			Exec(a, "INLINE_VAR=inline env", ClearEnv(), Stdout(&output))
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := output.String()
+	if !strings.Contains(got, "INLINE_VAR=inline") {
+		t.Error("INLINE_VAR=inline should be present even if environment was cleared by option")
+	}
+
+	if strings.Contains(got, "GOYEK_HIDDEN=") {
+		t.Error("GOYEK_HIDDEN should not be present")
+	}
+}
+
+func TestExec_EnvOption_WithInlineEnv(t *testing.T) {
+	f := &goyek.Flow{}
+	var output strings.Builder
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			Exec(a, "VAR=inline env", Env("VAR", "option"), Stdout(&output))
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := output.String()
+	// Both will be present in cmd.Env, but the last one wins in most OSes
+	// and cmd.Env is usually processed from first to last.
+	// Actually, exec.Cmd.Env says "If Env contains duplicate environment keys, only the last value in the slice for each duplicate key is used."
+	if !strings.Contains(got, "VAR=inline") {
+		t.Error("VAR=inline should be present")
+	}
+	if strings.HasSuffix(strings.TrimSpace(got), "VAR=option") {
+		t.Error("VAR=inline should override VAR=option")
 	}
 }
 


### PR DESCRIPTION
Fixed a security/robustness issue in `cmd.Env` where it would accidentally clear environment inheritance if it was the first option to modify `cmd.Env`. Also improved `cmd.Exec` by reordering operations so that inline environment variables in the command line string always have highest precedence and are not affected by environment-clearing options. Added comprehensive unit tests to verify these behaviors and prevent regressions.

---
*PR created automatically by Jules for task [6499996907005602478](https://jules.google.com/task/6499996907005602478) started by @pellared*