### PR TITLE
Fix environment variable handling in cmd package

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -36,10 +36,10 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	cmd.Stdout = a.Output()
 	cmd.Stderr = a.Output()
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, envs...)
 	for _, opt := range opts {
 		opt(a, cmd)
 	}
+	cmd.Env = append(cmd.Env, envs...)
 
 	if err := cmd.Run(); err != nil {
 		a.Error(err)
@@ -58,6 +58,9 @@ func Dir(s string) Option {
 // Env is an option to set an environment variable.
 func Env(k, v string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {
+		if cmd.Env == nil {
+			cmd.Env = os.Environ()
+		}
 		env := k + "=" + v
 		cmd.Env = append(cmd.Env, env)
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -78,6 +78,36 @@ func TestUnsetEnv_Nil(t *testing.T) {
 	}
 }
 
+func TestEnv_Inheritance(t *testing.T) {
+	t.Setenv("GOYEK_TEST_VAR", "present")
+	a := &goyek.A{}
+	cmd := &exec.Cmd{
+		Env: nil,
+	}
+
+	Env("NEW_VAR", "value")(a, cmd)
+
+	if cmd.Env == nil {
+		t.Fatal("expected Env not to be nil")
+	}
+	foundTestVar := false
+	foundNewVar := false
+	for _, e := range cmd.Env {
+		if e == "GOYEK_TEST_VAR=present" {
+			foundTestVar = true
+		}
+		if e == "NEW_VAR=value" {
+			foundNewVar = true
+		}
+	}
+	if !foundTestVar {
+		t.Error("expected GOYEK_TEST_VAR to be inherited from the environment")
+	}
+	if !foundNewVar {
+		t.Error("expected NEW_VAR=value to be present")
+	}
+}
+
 func TestClearEnv(t *testing.T) {
 	a := &goyek.A{}
 	cmd := &exec.Cmd{
@@ -108,6 +138,24 @@ func TestExec_ClearEnv(t *testing.T) {
 	got := output.String()
 	if strings.Contains(got, "GOYEK_TEST_VAR=present") {
 		t.Error("GOYEK_TEST_VAR should not be present in a cleared environment")
+	}
+}
+
+func TestExec_ClearEnv_InlineVars(t *testing.T) {
+	var output strings.Builder
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			Exec(a, "FOO=bar env", ClearEnv(), Stdout(&output))
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := output.String()
+	if !strings.Contains(got, "FOO=bar") {
+		t.Errorf("FOO=bar should be present even if ClearEnv is used, got:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
Fixed a security-related pitfall where adding a single environment variable via `cmd.Env` or inline in `cmd.Exec` could unintentionally strip all other inherited environment variables (like `PATH`). Also ensured that inline environment variables in `cmd.Exec` have the highest precedence, consistent with shell-like behavior.

---
*PR created automatically by Jules for task [4536127898931635416](https://jules.google.com/task/4536127898931635416) started by @pellared*