### PR TITLE
Improve environment variables handling in cmd package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this library adheres to
 
 - Remove logging from `cmd.Exec`, `cmd.Dir`, and `cmd.Env` to prevent sensitive
   information leakage.
+- Improve environment variables handling in `cmd.Exec` to ensure inline
+  variables have the highest precedence and are not affected by `cmd.ClearEnv`.
+- Improve `cmd.Env` option to ensure environment inheritance if `cmd.Env`
+  is `nil`.
 
 ### Fixed
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -36,10 +36,10 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	cmd.Stdout = a.Output()
 	cmd.Stderr = a.Output()
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, envs...)
 	for _, opt := range opts {
 		opt(a, cmd)
 	}
+	cmd.Env = append(cmd.Env, envs...)
 
 	if err := cmd.Run(); err != nil {
 		a.Error(err)
@@ -58,6 +58,9 @@ func Dir(s string) Option {
 // Env is an option to set an environment variable.
 func Env(k, v string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {
+		if cmd.Env == nil {
+			cmd.Env = os.Environ()
+		}
 		env := k + "=" + v
 		cmd.Env = append(cmd.Env, env)
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -175,3 +175,70 @@ func TestExec_EnvOnly(t *testing.T) {
 	}()
 	Exec(&goyek.A{}, "FOO=bar")
 }
+
+func TestEnv_Inheritance(t *testing.T) {
+	t.Setenv("GOYEK_TEST_VAR", "present")
+	a := &goyek.A{}
+	cmd := &exec.Cmd{} // Env is nil
+
+	Env("NEW_VAR", "value")(a, cmd)
+
+	foundTestVar := false
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "GOYEK_TEST_VAR=") {
+			foundTestVar = true
+			break
+		}
+	}
+	if !foundTestVar {
+		t.Error("expected GOYEK_TEST_VAR to be inherited when using Env option on nil cmd.Env")
+	}
+}
+
+func TestExec_Precedence(t *testing.T) {
+	f := &goyek.Flow{}
+	var output strings.Builder
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			// Inline FOO=baz should override Option Env FOO=bar
+			// We use 'env' command to print the environment
+			Exec(a, "FOO=baz env", Env("FOO", "bar"), Stdout(&output))
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := output.String()
+	// In Go exec.Cmd.Env, the last one wins.
+	lines := strings.Split(got, "\n")
+	var lastFoo string
+	for _, line := range lines {
+		if strings.HasPrefix(line, "FOO=") {
+			lastFoo = line
+		}
+	}
+
+	if lastFoo != "FOO=baz" {
+		t.Errorf("expected FOO=baz to have higher precedence, but got %q", lastFoo)
+	}
+}
+
+func TestExec_ClearEnv_Inline(t *testing.T) {
+	f := &goyek.Flow{}
+	var output strings.Builder
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			// Inline FOO=baz should NOT be cleared by ClearEnv()
+			Exec(a, "FOO=baz env", ClearEnv(), Stdout(&output))
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := output.String()
+	if !strings.Contains(got, "FOO=baz") {
+		t.Error("FOO=baz was lost due to ClearEnv()")
+	}
+}


### PR DESCRIPTION
This change improves the robustness and security of the cmd package by ensuring that inline environment variables have the highest precedence and that the Env option preserves environment inheritance. Specifically, it reorders operations in cmd.Exec to apply options before appending inline variables, and updates the Env option to initialize cmd.Env with os.Environ() if it is nil.

---
*PR created automatically by Jules for task [4713473750948651741](https://jules.google.com/task/4713473750948651741) started by @pellared*