### PR TITLE
Fix environment inheritance and precedence in 'cmd' package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this library adheres to
 
 ### Fixed
 
+- Fix `cmd.Env` option to preserve environment inheritance by initializing
+  `cmd.Env` with `os.Environ()` if it is nil.
+- Fix precedence in `cmd.Exec` so that inline environment variables
+  have the highest precedence and are not cleared by `cmd.ClearEnv`.
 - Fix races in `otelgoyek` when task output is written from multiple
   goroutines.
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -36,10 +36,10 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	cmd.Stdout = a.Output()
 	cmd.Stderr = a.Output()
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, envs...)
 	for _, opt := range opts {
 		opt(a, cmd)
 	}
+	cmd.Env = append(cmd.Env, envs...)
 
 	if err := cmd.Run(); err != nil {
 		a.Error(err)
@@ -58,6 +58,9 @@ func Dir(s string) Option {
 // Env is an option to set an environment variable.
 func Env(k, v string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {
+		if cmd.Env == nil {
+			cmd.Env = os.Environ()
+		}
 		env := k + "=" + v
 		cmd.Env = append(cmd.Env, env)
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -78,6 +78,31 @@ func TestUnsetEnv_Nil(t *testing.T) {
 	}
 }
 
+func TestEnv_Inheritance(t *testing.T) {
+	t.Setenv("GOYEK_TEST_VAR", "present")
+	a := &goyek.A{}
+	cmd := &exec.Cmd{}
+
+	Env("NEW_VAR", "value")(a, cmd)
+
+	foundInherited := false
+	foundNew := false
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "GOYEK_TEST_VAR=") {
+			foundInherited = true
+		}
+		if e == "NEW_VAR=value" {
+			foundNew = true
+		}
+	}
+	if !foundInherited {
+		t.Error("inherited environment lost")
+	}
+	if !foundNew {
+		t.Error("NEW_VAR=value not found")
+	}
+}
+
 func TestClearEnv(t *testing.T) {
 	a := &goyek.A{}
 	cmd := &exec.Cmd{
@@ -127,6 +152,29 @@ func TestExec_ClearEnv_WithEnv(t *testing.T) {
 	got := output.String()
 	if !strings.Contains(got, "NEW_VAR=value") {
 		t.Error("NEW_VAR=value should be present")
+	}
+
+	if strings.Contains(got, "GOYEK_HIDDEN=") {
+		t.Error("GOYEK_HIDDEN should not be present")
+	}
+}
+
+func TestExec_ClearEnv_WithInlineEnv(t *testing.T) {
+	t.Setenv("GOYEK_HIDDEN", "secret")
+	f := &goyek.Flow{}
+	var output strings.Builder
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			Exec(a, "INLINE_VAR=value env", ClearEnv(), Stdout(&output))
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := output.String()
+	if !strings.Contains(got, "INLINE_VAR=value") {
+		t.Error("INLINE_VAR=value should be present even if environment was cleared")
 	}
 
 	if strings.Contains(got, "GOYEK_HIDDEN=") {


### PR DESCRIPTION
This change addresses a few security and robustness issues in the `cmd` package:
1. **Environment Inheritance in `cmd.Env`**: Previously, using `cmd.Env` on a fresh `exec.Cmd` would cause it to lose inherited environment variables (like `PATH`), as Go's `exec.Cmd` treats a non-nil (even if single-element) `Env` slice as a complete replacement of the environment. The fix ensures that `os.Environ()` is loaded if the environment was previously `nil`.
2. **Precedence in `cmd.Exec`**: Inline environment variables (e.g., `Exec(a, "FOO=bar cmd")`) were previously applied before functional options. This meant `ClearEnv()` would wipe out explicitly provided inline variables. Reordering these ensures inline variables have the highest precedence, which is more intuitive and secure when sandboxing commands.

Regression tests were added to `cmd/cmd_test.go` to verify these fixes.

---
*PR created automatically by Jules for task [7151547509599870271](https://jules.google.com/task/7151547509599870271) started by @pellared*