### PR TITLE
Fix cmd environment variable inheritance and precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this library adheres to
 
 - Fix races in `otelgoyek` when task output is written from multiple
   goroutines.
+- Fix environment inheritance in `cmd.Env` and reorder environment variable
+  setup in `cmd.Exec` to ensure inline variables have highest precedence and
+  are preserved after `cmd.ClearEnv`.
 
 ### Removed
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -36,10 +36,10 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	cmd.Stdout = a.Output()
 	cmd.Stderr = a.Output()
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, envs...)
 	for _, opt := range opts {
 		opt(a, cmd)
 	}
+	cmd.Env = append(cmd.Env, envs...)
 
 	if err := cmd.Run(); err != nil {
 		a.Error(err)
@@ -58,6 +58,9 @@ func Dir(s string) Option {
 // Env is an option to set an environment variable.
 func Env(k, v string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {
+		if cmd.Env == nil {
+			cmd.Env = os.Environ()
+		}
 		env := k + "=" + v
 		cmd.Env = append(cmd.Env, env)
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -175,3 +175,69 @@ func TestExec_EnvOnly(t *testing.T) {
 	}()
 	Exec(&goyek.A{}, "FOO=bar")
 }
+
+func TestExec_InlineEnvPrecedence(t *testing.T) {
+	f := &goyek.Flow{}
+	var output strings.Builder
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			Exec(a, "FOO=inline env", Env("FOO", "option"), Stdout(&output))
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := output.String()
+	if !strings.Contains(got, "FOO=inline") {
+		t.Errorf("expected inline FOO to take precedence, but got: %s", got)
+	}
+}
+
+func TestExec_ClearEnv_WithInlineEnv(t *testing.T) {
+	t.Setenv("GOYEK_HIDDEN", "secret")
+	f := &goyek.Flow{}
+	var output strings.Builder
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			Exec(a, "NEW_VAR=value env", ClearEnv(), Stdout(&output))
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := output.String()
+	if !strings.Contains(got, "NEW_VAR=value") {
+		t.Error("NEW_VAR=value should be present even if environment was cleared")
+	}
+
+	if strings.Contains(got, "GOYEK_HIDDEN=") {
+		t.Error("GOYEK_HIDDEN should not be present")
+	}
+}
+
+func TestEnv_Inheritance(t *testing.T) {
+	t.Setenv("GOYEK_TEST_VAR", "present")
+	a := &goyek.A{}
+	cmd := &exec.Cmd{}
+
+	Env("NEW_VAR", "value")(a, cmd)
+
+	foundTestVar := false
+	foundNewVar := false
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "GOYEK_TEST_VAR=") {
+			foundTestVar = true
+		}
+		if e == "NEW_VAR=value" {
+			foundNewVar = true
+		}
+	}
+	if !foundTestVar {
+		t.Error("expected GOYEK_TEST_VAR to be inherited")
+	}
+	if !foundNewVar {
+		t.Error("expected NEW_VAR=value to be set")
+	}
+}


### PR DESCRIPTION
Improved the security and robustness of environment variable handling in the `cmd` package. 

Previously, the `Env` option would accidentally clear the inherited environment if used on a fresh `exec.Cmd`. Additionally, inline environment variables (e.g., `FOO=bar ./cmd`) were applied before options, meaning they could be wiped out by `ClearEnv()` or overridden by the `Env` option.

This change:
1. Ensures `Env` option initializes `cmd.Env` from `os.Environ()` if it is `nil`.
2. Reorders operations in `Exec` so that inline variables are appended last, giving them the highest precedence and ensuring they are not lost when using `ClearEnv()`.
3. Adds comprehensive regression tests for these scenarios.
4. Updates the `CHANGELOG.md` to reflect these fixes.

---
*PR created automatically by Jules for task [2106816060464585509](https://jules.google.com/task/2106816060464585509) started by @pellared*