### PR TITLE
Improve environment variable handling in cmd package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this library adheres to
   environment variables.
 - Add `cmd.ClearEnv` option to prevent environment inheritance in `cmd.Exec`.
 - Add `cmd.UnsetEnv` option to remove a specific environment variable in `cmd.Exec`.
+- Improve `cmd.Env` to ensure environment inheritance.
+- Change `cmd.Exec` to ensure inline environment variables have the highest precedence.
 
 ### Changed
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -36,10 +36,10 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	cmd.Stdout = a.Output()
 	cmd.Stderr = a.Output()
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, envs...)
 	for _, opt := range opts {
 		opt(a, cmd)
 	}
+	cmd.Env = append(cmd.Env, envs...)
 
 	if err := cmd.Run(); err != nil {
 		a.Error(err)
@@ -58,6 +58,9 @@ func Dir(s string) Option {
 // Env is an option to set an environment variable.
 func Env(k, v string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {
+		if cmd.Env == nil {
+			cmd.Env = os.Environ()
+		}
 		env := k + "=" + v
 		cmd.Env = append(cmd.Env, env)
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -175,3 +175,63 @@ func TestExec_EnvOnly(t *testing.T) {
 	}()
 	Exec(&goyek.A{}, "FOO=bar")
 }
+
+func TestEnv_Inheritance(t *testing.T) {
+	t.Setenv("GOYEK_TEST_VAR", "present")
+	a := &goyek.A{}
+	cmd := &exec.Cmd{
+		Env: nil,
+	}
+
+	Env("NEW_VAR", "value")(a, cmd)
+
+	if cmd.Env == nil {
+		t.Error("expected Env not to be nil")
+	}
+	found := false
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "GOYEK_TEST_VAR=") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected GOYEK_TEST_VAR to be inherited")
+	}
+}
+
+func TestExec_InlineEnvPrecedence(t *testing.T) {
+	f := &goyek.Flow{}
+	var output strings.Builder
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			Exec(a, "FOO=inline env", Env("FOO", "option"), Stdout(&output))
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := output.String()
+	if !strings.Contains(got, "FOO=inline") {
+		t.Errorf("FOO should be 'inline', but got: %s", got)
+	}
+}
+
+func TestExec_ClearEnv_WithInlineEnv(t *testing.T) {
+	f := &goyek.Flow{}
+	var output strings.Builder
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			Exec(a, "FOO=inline env", ClearEnv(), Stdout(&output))
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := output.String()
+	if !strings.Contains(got, "FOO=inline") {
+		t.Errorf("FOO should be 'inline' even with ClearEnv, but got: %s", got)
+	}
+}


### PR DESCRIPTION
This change improves the security and robustness of environment variable handling in the cmd package by ensuring environment inheritance in the Env option and establishing correct precedence for inline environment variables in Exec.

---
*PR created automatically by Jules for task [15426518104223136398](https://jules.google.com/task/15426518104223136398) started by @pellared*