### PR TITLE
Fix environment variable handling in cmd package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this library adheres to
 
 - Fix races in `otelgoyek` when task output is written from multiple
   goroutines.
+- Fix environment variable handling in `cmd.Exec` and `cmd.Env` to ensure inherited
+  environment is preserved and inline variables have the highest precedence.
 
 ### Removed
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -36,10 +36,10 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	cmd.Stdout = a.Output()
 	cmd.Stderr = a.Output()
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, envs...)
 	for _, opt := range opts {
 		opt(a, cmd)
 	}
+	cmd.Env = append(cmd.Env, envs...)
 
 	if err := cmd.Run(); err != nil {
 		a.Error(err)
@@ -58,6 +58,9 @@ func Dir(s string) Option {
 // Env is an option to set an environment variable.
 func Env(k, v string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {
+		if cmd.Env == nil {
+			cmd.Env = os.Environ()
+		}
 		env := k + "=" + v
 		cmd.Env = append(cmd.Env, env)
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -175,3 +175,57 @@ func TestExec_EnvOnly(t *testing.T) {
 	}()
 	Exec(&goyek.A{}, "FOO=bar")
 }
+
+func TestExec_ClearEnv_InlineEnv(t *testing.T) {
+	f := &goyek.Flow{}
+	var output strings.Builder
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			// We want to clear the inherited env but keep the inline one
+			Exec(a, "GOYEK_INLINE=present env", ClearEnv(), Stdout(&output))
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := output.String()
+	if !strings.Contains(got, "GOYEK_INLINE=present") {
+		t.Errorf("GOYEK_INLINE=present should be present in the output, but got:\n%s", got)
+	}
+}
+
+func TestEnv_NilInheritance(t *testing.T) {
+	t.Setenv("GOYEK_EXPECTED", "should-stay")
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			// Adding one env var should NOT drop the others from process environment
+			// Functional options are applied to &exec.Cmd{} which has Env = nil.
+			cmd := &exec.Cmd{}
+			Env("NEW_VAR", "value")(a, cmd)
+			if cmd.Env == nil {
+				t.Fatal("cmd.Env should not be nil after Env option")
+			}
+			foundInherited := false
+			foundNew := false
+			for _, e := range cmd.Env {
+				if e == "GOYEK_EXPECTED=should-stay" {
+					foundInherited = true
+				}
+				if e == "NEW_VAR=value" {
+					foundNew = true
+				}
+			}
+			if !foundInherited {
+				t.Error("inherited GOYEK_EXPECTED=should-stay was lost")
+			}
+			if !foundNew {
+				t.Error("new NEW_VAR=value was not added")
+			}
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+}


### PR DESCRIPTION
I have fixed a security and reliability issue in the `cmd` package where the inherited process environment could be accidentally wiped when using the `Env` option, and where inline environment variables were incorrectly overridden or wiped by functional options.

### Changes:
- Modified `cmd.Env` option to initialize `cmd.Env` from `os.Environ()` if it is `nil`, preserving inheritance when adding variables.
- Updated `cmd.Exec` to apply functional options *before* appending inline environment variables, ensuring inline variables have the highest precedence and survive `ClearEnv()`.
- Added regression tests in `cmd/cmd_test.go`.
- Updated `CHANGELOG.md` with the fixes.

---
*PR created automatically by Jules for task [13131844625427873906](https://jules.google.com/task/13131844625427873906) started by @pellared*