### PR TITLE
Security hardening: environment isolation and panic observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,10 @@ and this library adheres to
 
 ### Fixed
 
+- Fix environment variable precedence and inheritance in `cmd.Exec`.
 - Fix races in `otelgoyek` when task output is written from multiple
   goroutines.
+- Fix OpenTelemetry span status when a task panics in `otelgoyek`.
 
 ### Removed
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -35,11 +35,14 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = a.Output()
 	cmd.Stderr = a.Output()
-	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, envs...)
+
 	for _, opt := range opts {
 		opt(a, cmd)
 	}
+	if cmd.Env == nil {
+		cmd.Env = os.Environ()
+	}
+	cmd.Env = append(cmd.Env, envs...)
 
 	if err := cmd.Run(); err != nil {
 		a.Error(err)
@@ -58,6 +61,9 @@ func Dir(s string) Option {
 // Env is an option to set an environment variable.
 func Env(k, v string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {
+		if cmd.Env == nil {
+			cmd.Env = os.Environ()
+		}
 		env := k + "=" + v
 		cmd.Env = append(cmd.Env, env)
 	}

--- a/cmd/repro_test.go
+++ b/cmd/repro_test.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestExec_ClearEnv_InlineEnv(t *testing.T) {
+	f := &goyek.Flow{}
+	var output strings.Builder
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			Exec(a, "FOO=bar env", ClearEnv(), Stdout(&output))
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := output.String()
+	if !strings.Contains(got, "FOO=bar") {
+		t.Error("FOO=bar should be present even if ClearEnv() is used, as it was specified in the command line")
+	}
+	// Check that other environment variables are NOT present (e.g. PATH)
+	if strings.Contains(got, "PATH=") {
+		t.Error("PATH should not be present when ClearEnv() is used")
+	}
+}
+
+func TestExec_Env_InlineEnv_Precedence(t *testing.T) {
+	f := &goyek.Flow{}
+	var output strings.Builder
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			// Inline FOO=inline should win over Env("FOO", "option")
+			Exec(a, "FOO=inline env", Env("FOO", "option"), Stdout(&output))
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := output.String()
+	if !strings.Contains(got, "FOO=inline") {
+		t.Errorf("FOO=inline should be present, got: %s", got)
+	}
+	if strings.Contains(got, "FOO=option") {
+		t.Error("FOO=option should have been overridden by inline variable")
+	}
+}
+
+func TestEnv_Inheritance(t *testing.T) {
+	t.Setenv("GOYEK_INHERITED", "true")
+
+	a := &goyek.A{}
+	c := &exec.Cmd{} // Env is nil
+
+	Env("FOO", "bar")(a, c)
+
+	foundInherited := false
+	foundNew := false
+	for _, e := range c.Env {
+		if e == "GOYEK_INHERITED=true" {
+			foundInherited = true
+		}
+		if e == "FOO=bar" {
+			foundNew = true
+		}
+	}
+
+	if !foundInherited {
+		t.Error("expected inherited environment to be preserved by Env option")
+	}
+	if !foundNew {
+		t.Error("expected new environment variable to be set by Env option")
+	}
+}
+
+func TestEnv_NilInheritance(t *testing.T) {
+	// This tests the case where cmd.Env is nil and we call Env option.
+	// It should initialize cmd.Env with os.Environ().
+	t.Setenv("GOYEK_TEST_VAR", "present")
+	a := &goyek.A{}
+	cmd := &exec.Cmd{
+		Env: nil,
+	}
+
+	Env("OTHER_VAR", "value")(a, cmd)
+
+	if cmd.Env == nil {
+		t.Fatal("expected Env not to be nil")
+	}
+
+	foundInherited := false
+	foundOther := false
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "GOYEK_TEST_VAR=") {
+			foundInherited = true
+		}
+		if e == "OTHER_VAR=value" {
+			foundOther = true
+		}
+	}
+	if !foundInherited {
+		t.Error("Inherited environment missing")
+	}
+	if !foundOther {
+		t.Error("New environment variable missing")
+	}
+}

--- a/otelgoyek/otelgoyek.go
+++ b/otelgoyek/otelgoyek.go
@@ -135,6 +135,14 @@ func (r *runner) Middleware(next goyek.Runner) goyek.Runner {
 			span.SetStatus(codes.Error, "task failed: "+in.TaskName)
 		}
 
+		if res.PanicStack != nil {
+			msg := "task panicked: " + in.TaskName
+			if r.disableOutput {
+				msg = "task execution failed"
+			}
+			span.SetStatus(codes.Error, msg)
+		}
+
 		if res.PanicStack != nil && !r.disableOutput {
 			if res.PanicValue != nil {
 				val := fmt.Sprint(res.PanicValue)

--- a/otelgoyek/otelgoyek_test.go
+++ b/otelgoyek/otelgoyek_test.go
@@ -16,11 +16,13 @@ import (
 	"github.com/goyek/x/otelgoyek"
 )
 
-const attrTaskOutput = "goyek.task.output"
-const traceparent = "00-0102030405060708090a0b0c0d0e0f10-0102030405060708-01"
-const spanNameExecute = "Execute"
-const taskNameTest = "test"
-const taskNamePanic = "panic"
+const (
+	attrTaskOutput  = "goyek.task.output"
+	traceparent     = "00-0102030405060708090a0b0c0d0e0f10-0102030405060708-01"
+	spanNameExecute = "Execute"
+	taskNameTest    = "test"
+	taskNamePanic   = "panic"
+)
 
 func TestMiddleware_WithDisableOutput(t *testing.T) {
 	exp, tp := setupOTel()
@@ -133,7 +135,7 @@ func TestExecutorMiddleware_ErrorTruncation(t *testing.T) {
 	)
 
 	next := func(_ goyek.ExecuteInput) error {
-		return fmt.Errorf("1234567890")
+		return errors.New("1234567890")
 	}
 
 	executor := mw(next)

--- a/otelgoyek/repro_panic_test.go
+++ b/otelgoyek/repro_panic_test.go
@@ -1,0 +1,53 @@
+package otelgoyek_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/goyek/x/otelgoyek"
+)
+
+func TestMiddleware_PanicStatus_Repro(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(
+		trace.WithSpanProcessor(trace.NewSimpleSpanProcessor(exp)),
+	)
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "panic",
+		Action: func(_ *goyek.A) {
+			panic("something went wrong")
+		},
+	})
+	f.Use(otelgoyek.Middleware(otelgoyek.WithTracerProvider(tp)))
+
+	_ = f.Execute(context.Background(), []string{"panic"})
+
+	spans := exp.GetSpans()
+	var taskSpan *tracetest.SpanStub
+	for _, s := range spans {
+		if s.Name == "panic" {
+			taskSpan = &s
+			break
+		}
+	}
+
+	if taskSpan == nil {
+		t.Fatal("task span not found")
+	}
+
+	if taskSpan.Status.Code != codes.Error {
+		t.Errorf("expected span status Error, got %v", taskSpan.Status.Code)
+	}
+
+	expectedMsg := "task panicked: panic"
+	if taskSpan.Status.Description != expectedMsg {
+		t.Errorf("expected span status description %q, got %q", expectedMsg, taskSpan.Status.Description)
+	}
+}


### PR DESCRIPTION
Hardened the codebase by fixing environment variable precedence/inheritance in `cmd.Exec` and ensuring task panics are reported as errors in OpenTelemetry traces. Added regression tests and updated the changelog.

---
*PR created automatically by Jules for task [5237095584794433574](https://jules.google.com/task/5237095584794433574) started by @pellared*