### PR TITLE
Fix environment variable inheritance and precedence in cmd package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this library adheres to
 
 ### Fixed
 
+- Fix environment variable inheritance in `cmd.Env`.
+- Fix environment variable precedence in `cmd.Exec` to ensure inline variables
+  are not stripped by options.
 - Fix races in `otelgoyek` when task output is written from multiple
   goroutines.
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -36,10 +36,10 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	cmd.Stdout = a.Output()
 	cmd.Stderr = a.Output()
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, envs...)
 	for _, opt := range opts {
 		opt(a, cmd)
 	}
+	cmd.Env = append(cmd.Env, envs...)
 
 	if err := cmd.Run(); err != nil {
 		a.Error(err)
@@ -58,6 +58,9 @@ func Dir(s string) Option {
 // Env is an option to set an environment variable.
 func Env(k, v string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {
+		if cmd.Env == nil {
+			cmd.Env = os.Environ()
+		}
 		env := k + "=" + v
 		cmd.Env = append(cmd.Env, env)
 	}

--- a/cmd/repro_test.go
+++ b/cmd/repro_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestExec_ClearEnv_InlineEnv(t *testing.T) {
+	f := &goyek.Flow{}
+	var output strings.Builder
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			Exec(a, "FOO=bar env", ClearEnv(), Stdout(&output))
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := output.String()
+	if !strings.Contains(got, "FOO=bar") {
+		t.Error("FOO=bar should be present even if ClearEnv() is used")
+	}
+}
+
+func TestEnv_NilInheritance(t *testing.T) {
+	t.Setenv("GOYEK_TEST_VAR", "present")
+	a := &goyek.A{}
+	cmd := &exec.Cmd{
+		Env: nil,
+	}
+
+	Env("NEW_VAR", "value")(a, cmd)
+
+	foundInherited := false
+	foundNew := false
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "GOYEK_TEST_VAR=") {
+			foundInherited = true
+		}
+		if e == "NEW_VAR=value" {
+			foundNew = true
+		}
+	}
+
+	if !foundInherited {
+		t.Error("expected inherited environment variable to be present")
+	}
+	if !foundNew {
+		t.Error("expected NEW_VAR=value to be present")
+	}
+}


### PR DESCRIPTION
This change fixes two issues in the `cmd` package related to environment variable handling:

1. **Environment Inheritance in `cmd.Env`**: Previously, using the `cmd.Env` option on a command with a `nil` environment would cause Go's `os/exec` to strip all inherited environment variables (like `PATH`) and use only the newly added variable. The fix ensures that `os.Environ()` is loaded if the environment is `nil`, preserving inheritance.

2. **Inline Variable Precedence in `cmd.Exec`**: In `cmd.Exec`, options were applied after inline environment variables were appended. This allowed options like `ClearEnv` to unintentionally wipe out variables explicitly provided in the command line (e.g., `VAR=val ./cmd`). The fix reorders these operations so that options are applied first, and inline variables are appended last, giving them the highest precedence.

Regression tests have been added to `cmd/repro_test.go` to verify these behaviors and prevent future regressions. `CHANGELOG.md` has also been updated.

---
*PR created automatically by Jules for task [12665437968179438208](https://jules.google.com/task/12665437968179438208) started by @pellared*