### PR TITLE
Fix environment inheritance and precedence in cmd package

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -36,10 +36,10 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	cmd.Stdout = a.Output()
 	cmd.Stderr = a.Output()
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, envs...)
 	for _, opt := range opts {
 		opt(a, cmd)
 	}
+	cmd.Env = append(cmd.Env, envs...)
 
 	if err := cmd.Run(); err != nil {
 		a.Error(err)
@@ -58,6 +58,9 @@ func Dir(s string) Option {
 // Env is an option to set an environment variable.
 func Env(k, v string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {
+		if cmd.Env == nil {
+			cmd.Env = os.Environ()
+		}
 		env := k + "=" + v
 		cmd.Env = append(cmd.Env, env)
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -134,6 +134,44 @@ func TestExec_ClearEnv_WithEnv(t *testing.T) {
 	}
 }
 
+func TestEnv_NilInheritance(t *testing.T) {
+	t.Setenv("PARENT_VAR", "parent-value")
+	a := &goyek.A{}
+	cmd := &exec.Cmd{}
+
+	Env("NEW_VAR", "new-value")(a, cmd)
+
+	foundParent := false
+	for _, e := range cmd.Env {
+		if e == "PARENT_VAR=parent-value" {
+			foundParent = true
+			break
+		}
+	}
+
+	if !foundParent {
+		t.Error("expected PARENT_VAR to be inherited, but it was lost")
+	}
+}
+
+func TestExec_ClearEnv_InlineEnv(t *testing.T) {
+	f := &goyek.Flow{}
+	var output strings.Builder
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			Exec(a, "FOO=bar env", ClearEnv(), Stdout(&output))
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := output.String()
+	if !strings.Contains(got, "FOO=bar") {
+		t.Error("FOO=bar should be present even if ClearEnv() was used")
+	}
+}
+
 func TestExec_UnsetEnv(t *testing.T) {
 	t.Setenv("GOYEK_TEST_VAR", "present")
 	t.Setenv("ANOTHER_VAR", "stay")


### PR DESCRIPTION
This PR fixes two issues in the `cmd` package related to environment variable handling:

1. **Accidental environment isolation in `Env` option**: Previously, using `cmd.Env("VAR", "VAL")` on a command that was inheriting the parent environment (the default state) would cause it to lose all inherited variables (like `PATH`) because it would create a new environment slice with only the one variable. It now correctly snapshots `os.Environ()` if inheritance was active.
2. **Incorrect precedence in `Exec`**: Inline environment variables provided in the command string (e.g., `cmd.Exec(a, "FOO=bar ./cmd")`) were being applied before options. This meant an option like `ClearEnv()` would wipe out variables explicitly defined in the command string. Now, options are applied first, and inline variables are appended last to ensure they have the highest priority.

Regression tests for both fixes have been added to `cmd/cmd_test.go`.

---
*PR created automatically by Jules for task [4984475856761889067](https://jules.google.com/task/4984475856761889067) started by @pellared*