### PR TITLE
Mask sensitive inline environment variables in runExec logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this library adheres to
 
 ### Fixed
 
+- Mask sensitive inline environment variables in `runExec` logs.
 - Fix races in `otelgoyek` when task output is written from multiple
   goroutines.
 

--- a/build/go.mod
+++ b/build/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/golangci/golangci-lint/v2 v2.11.4
 	github.com/goyek/goyek/v3 v3.0.1
 	github.com/goyek/x v0.0.0-00010101000000-000000000000
+	github.com/mattn/go-shellwords v1.0.13
 )
 
 require (
@@ -136,7 +137,6 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
-	github.com/mattn/go-shellwords v1.0.13 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mgechev/revive v1.15.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/build/helper.go
+++ b/build/helper.go
@@ -17,7 +17,7 @@ func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
 	if err == nil && len(envs) > 0 {
 		var sb strings.Builder
 		for _, env := range envs {
-			if split := strings.SplitN(env, "=", 2); len(split) == 2 {
+			if split := strings.SplitN(env, "=", 2); len(split) == 2 { //nolint:mnd // splitting key=value
 				sb.WriteString(split[0])
 				sb.WriteString("=[MASKED] ")
 			}

--- a/build/helper.go
+++ b/build/helper.go
@@ -1,14 +1,32 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/goyek/goyek/v3"
+	"github.com/mattn/go-shellwords"
 
 	"github.com/goyek/x/cmd"
 )
 
 func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
 	a.Helper()
-	a.Log("Exec: ", cmdLine)
+
+	msg := cmdLine
+	envs, args, err := shellwords.ParseWithEnvs(cmdLine)
+	if err == nil && len(envs) > 0 {
+		var sb strings.Builder
+		for _, env := range envs {
+			if split := strings.SplitN(env, "=", 2); len(split) == 2 {
+				sb.WriteString(split[0])
+				sb.WriteString("=[MASKED] ")
+			}
+		}
+		sb.WriteString(strings.Join(args, " "))
+		msg = sb.String()
+	}
+
+	a.Log("Exec: ", msg)
 	return cmd.Exec(a, cmdLine, opts...)
 }
 

--- a/build/security_test.go
+++ b/build/security_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestRunExec_Masking(t *testing.T) {
+	sb := &strings.Builder{}
+
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = io.MultiWriter(in.Output, sb)
+			return next(in)
+		}
+	}
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			runExec(a, "SECRET=password echo hello")
+		},
+	})
+
+	// Use a new flow to avoid side effects
+	f.Use(mw)
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	if strings.Contains(got, "password") {
+		t.Errorf("Secret value was logged: %s", got)
+	}
+	if !strings.Contains(got, "SECRET=[MASKED] echo hello") {
+		t.Errorf("Secret was not masked correctly: %s", got)
+	}
+}


### PR DESCRIPTION
The runExec helper in build/helper.go now masks the values of inline environment variables (e.g., KEY=VALUE) with [MASKED] in its log output to prevent secret leakage in build logs. A new security test in build/security_test.go verifies this behavior.

---
*PR created automatically by Jules for task [8243076949982764748](https://jules.google.com/task/8243076949982764748) started by @pellared*