### PR TITLE
Mask inline environment variables in build logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this library adheres to
   environment variables.
 - Add `cmd.ClearEnv` option to prevent environment inheritance in `cmd.Exec`.
 - Add `cmd.UnsetEnv` option to remove a specific environment variable in `cmd.Exec`.
+- Add `cmd.Mask` function which masks the values of inline environment variables.
 
 ### Changed
 

--- a/build/helper.go
+++ b/build/helper.go
@@ -8,7 +8,7 @@ import (
 
 func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
 	a.Helper()
-	a.Log("Exec: ", cmdLine)
+	a.Log("Exec: ", cmd.Mask(cmdLine))
 	return cmd.Exec(a, cmdLine, opts...)
 }
 

--- a/build/security_test.go
+++ b/build/security_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestRunExec_Masking(t *testing.T) {
+	sb := &strings.Builder{}
+
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = io.MultiWriter(in.Output, sb)
+			return next(in)
+		}
+	}
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			runExec(a, "SECRET=password echo hello")
+		},
+	})
+
+	oldFlow := goyek.DefaultFlow
+	defer func() { goyek.DefaultFlow = oldFlow }()
+	goyek.DefaultFlow = f
+	goyek.Use(mw)
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	if strings.Contains(got, "password") {
+		t.Errorf("Secret value was logged: %s", got)
+	}
+	if !strings.Contains(got, "[MASKED]") {
+		t.Errorf("Expected [MASKED] in logs, but got: %s", got)
+	}
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -57,8 +57,8 @@ func Mask(cmdLine string) string {
 	}
 	newEnvs := make([]string, 0, len(envs))
 	for _, env := range envs {
-		split := strings.SplitN(env, "=", 2)
-		if len(split) == 2 {
+		split := strings.SplitN(env, "=", 2) //nolint:mnd // environment variable is k=v
+		if len(split) == 2 {                 //nolint:mnd // environment variable is k=v
 			newEnvs = append(newEnvs, split[0]+"=[MASKED]")
 		} else {
 			newEnvs = append(newEnvs, env)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -48,6 +48,25 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	return true
 }
 
+// Mask returns a masked version of the command line.
+// It replaces the values of inline environment variables with [MASKED].
+func Mask(cmdLine string) string {
+	envs, args, err := shellwords.ParseWithEnvs(cmdLine)
+	if err != nil {
+		return cmdLine
+	}
+	newEnvs := make([]string, 0, len(envs))
+	for _, env := range envs {
+		split := strings.SplitN(env, "=", 2)
+		if len(split) == 2 {
+			newEnvs = append(newEnvs, split[0]+"=[MASKED]")
+		} else {
+			newEnvs = append(newEnvs, env)
+		}
+	}
+	return strings.Join(append(newEnvs, args...), " ")
+}
+
 // Dir is an option to set the working directory.
 func Dir(s string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -175,3 +175,49 @@ func TestExec_EnvOnly(t *testing.T) {
 	}()
 	Exec(&goyek.A{}, "FOO=bar")
 }
+
+func TestMask(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdLine string
+		want    string
+	}{
+		{
+			name:    "empty",
+			cmdLine: "",
+			want:    "",
+		},
+		{
+			name:    "no env",
+			cmdLine: "echo hello",
+			want:    "echo hello",
+		},
+		{
+			name:    "one env",
+			cmdLine: "FOO=bar echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "two envs",
+			cmdLine: "FOO=bar BAZ=qux echo hello",
+			want:    "FOO=[MASKED] BAZ=[MASKED] echo hello",
+		},
+		{
+			name:    "env only",
+			cmdLine: "FOO=bar",
+			want:    "FOO=[MASKED]",
+		},
+		{
+			name:    "invalid",
+			cmdLine: "'unclosed quote",
+			want:    "'unclosed quote",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Mask(tt.cmdLine); got != tt.want {
+				t.Errorf("Mask() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/otelgoyek/otelgoyek_test.go
+++ b/otelgoyek/otelgoyek_test.go
@@ -16,11 +16,13 @@ import (
 	"github.com/goyek/x/otelgoyek"
 )
 
-const attrTaskOutput = "goyek.task.output"
-const traceparent = "00-0102030405060708090a0b0c0d0e0f10-0102030405060708-01"
-const spanNameExecute = "Execute"
-const taskNameTest = "test"
-const taskNamePanic = "panic"
+const (
+	attrTaskOutput  = "goyek.task.output"
+	traceparent     = "00-0102030405060708090a0b0c0d0e0f10-0102030405060708-01"
+	spanNameExecute = "Execute"
+	taskNameTest    = "test"
+	taskNamePanic   = "panic"
+)
 
 func TestMiddleware_WithDisableOutput(t *testing.T) {
 	exp, tp := setupOTel()
@@ -133,7 +135,7 @@ func TestExecutorMiddleware_ErrorTruncation(t *testing.T) {
 	)
 
 	next := func(_ goyek.ExecuteInput) error {
-		return fmt.Errorf("1234567890")
+		return errors.New("1234567890")
 	}
 
 	executor := mw(next)


### PR DESCRIPTION
This change addresses a security risk where sensitive information (like API tokens or passwords) passed as inline environment variables were being logged in plain text by the `runExec` helper.

Key changes:
- Added `cmd.Mask` to the `cmd` package to identify and mask `KEY=VALUE` patterns at the start of command strings.
- Updated `build/helper.go` to use `cmd.Mask` in the `runExec` logging call.
- Added `build/security_test.go` to verify that secrets are no longer leaked in task logs.
- Added unit tests for `cmd.Mask` in `cmd/cmd_test.go`.
- Updated `CHANGELOG.md` to reflect the new feature.

---
*PR created automatically by Jules for task [3084515406540739213](https://jules.google.com/task/3084515406540739213) started by @pellared*