### PR TITLE
Mask sensitive environment variables in build logs

### DIFF
--- a/build/helper.go
+++ b/build/helper.go
@@ -8,7 +8,7 @@ import (
 
 func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
 	a.Helper()
-	a.Log("Exec: ", cmdLine)
+	a.Log("Exec: ", cmd.Mask(cmdLine))
 	return cmd.Exec(a, cmdLine, opts...)
 }
 

--- a/build/security_test.go
+++ b/build/security_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestRunExec_Security(t *testing.T) {
+	sb := &strings.Builder{}
+
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = io.MultiWriter(in.Output, sb)
+			return next(in)
+		}
+	}
+
+	f := &goyek.Flow{}
+	f.Use(mw)
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			runExec(a, "SECRET=password echo hello")
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	fmt.Println("Captured output:", got)
+	if strings.Contains(got, "password") {
+		t.Errorf("Secret value from runExec was logged: %s", got)
+	}
+	if !strings.Contains(got, "SECRET=[MASKED]") {
+		t.Errorf("Secret value from runExec was NOT masked: %s", got)
+	}
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -48,6 +48,22 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	return true
 }
 
+// Mask replaces the values of leading environment variable assignments in a command line string with [MASKED].
+func Mask(cmdLine string) string {
+	envs, args, err := shellwords.ParseWithEnvs(cmdLine)
+	if err != nil || len(envs) == 0 {
+		return cmdLine
+	}
+	var sb strings.Builder
+	for _, env := range envs {
+		key, _, _ := strings.Cut(env, "=")
+		sb.WriteString(key)
+		sb.WriteString("=[MASKED] ")
+	}
+	sb.WriteString(strings.Join(args, " "))
+	return strings.TrimSpace(sb.String())
+}
+
 // Dir is an option to set the working directory.
 func Dir(s string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -175,3 +175,49 @@ func TestExec_EnvOnly(t *testing.T) {
 	}()
 	Exec(&goyek.A{}, "FOO=bar")
 }
+
+func TestMask(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdLine string
+		want    string
+	}{
+		{
+			name:    "no env vars",
+			cmdLine: "ls -l",
+			want:    "ls -l",
+		},
+		{
+			name:    "one env var",
+			cmdLine: "FOO=bar ls -l",
+			want:    "FOO=[MASKED] ls -l",
+		},
+		{
+			name:    "multiple env vars",
+			cmdLine: "FOO=bar BAZ=qux ls -l",
+			want:    "FOO=[MASKED] BAZ=[MASKED] ls -l",
+		},
+		{
+			name:    "quoted values",
+			cmdLine: `FOO="bar baz" ls -l`,
+			want:    "FOO=[MASKED] ls -l",
+		},
+		{
+			name:    "invalid command line",
+			cmdLine: `FOO="bar`,
+			want:    `FOO="bar`,
+		},
+		{
+			name:    "empty command line",
+			cmdLine: "",
+			want:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Mask(tt.cmdLine); got != tt.want {
+				t.Errorf("Mask() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces a security enhancement to prevent accidental secret leakage in logs. It adds a `Mask` function to the `cmd` package that identifies and masks leading environment variable assignments. This function is then integrated into the project's own build pipeline (`runExec` in `build/helper.go`) to ensure that any secrets passed as inline environment variables are not recorded in the task logs. Comprehensive tests are included to verify the masking logic and its application.

---
*PR created automatically by Jules for task [2680881781488723882](https://jules.google.com/task/2680881781488723882) started by @pellared*