### PR TITLE
Mask secrets in logs

### DIFF
--- a/build/helper.go
+++ b/build/helper.go
@@ -8,7 +8,7 @@ import (
 
 func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
 	a.Helper()
-	a.Log("Exec: ", cmdLine)
+	a.Log("Exec: ", cmd.Mask(cmdLine))
 	return cmd.Exec(a, cmdLine, opts...)
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -57,7 +57,7 @@ func Mask(cmdLine string) string {
 	}
 	var sb strings.Builder
 	for _, env := range envs {
-		split := strings.SplitN(env, "=", 2)
+		split := strings.SplitN(env, "=", 2) //nolint:mnd // environment variable is always key=value
 		sb.WriteString(split[0])
 		sb.WriteString("=[MASKED] ")
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -48,6 +48,23 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	return true
 }
 
+// Mask replaces the values of leading environment variable assignments
+// in a command line string with [MASKED].
+func Mask(cmdLine string) string {
+	envs, args, err := shellwords.ParseWithEnvs(cmdLine)
+	if err != nil || len(envs) == 0 {
+		return cmdLine
+	}
+	var sb strings.Builder
+	for _, env := range envs {
+		split := strings.SplitN(env, "=", 2)
+		sb.WriteString(split[0])
+		sb.WriteString("=[MASKED] ")
+	}
+	sb.WriteString(strings.Join(args, " "))
+	return sb.String()
+}
+
 // Dir is an option to set the working directory.
 func Dir(s string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -175,3 +175,50 @@ func TestExec_EnvOnly(t *testing.T) {
 	}()
 	Exec(&goyek.A{}, "FOO=bar")
 }
+
+func TestMask(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdLine string
+		want    string
+	}{
+		{
+			name:    "no env",
+			cmdLine: "echo hello",
+			want:    "echo hello",
+		},
+		{
+			name:    "single env",
+			cmdLine: "FOO=bar echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "multiple envs",
+			cmdLine: "FOO=bar BAZ=qux echo 'hello world'",
+			want:    "FOO=[MASKED] BAZ=[MASKED] echo hello world",
+		},
+		{
+			name:    "env with special chars",
+			cmdLine: "PASS='my password' ./login",
+			want:    "PASS=[MASKED] ./login",
+		},
+		{
+			name:    "only envs (invalid command, but Mask should handle it)",
+			cmdLine: "FOO=bar BAZ=qux",
+			want:    "FOO=[MASKED] BAZ=[MASKED] ",
+		},
+		{
+			name:    "empty",
+			cmdLine: "",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Mask(tt.cmdLine); got != tt.want {
+				t.Errorf("Mask() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implemented a security enhancement to prevent secret leakage in logs.
- Added `cmd.Mask` function to mask leading environment variables in command lines.
- Updated `build/helper.go` to use `cmd.Mask` in `runExec`.
- Added comprehensive unit tests for `cmd.Mask`.
- Cleaned up debug files and synchronized dependencies with `go mod tidy`.

---
*PR created automatically by Jules for task [5392216174230064923](https://jules.google.com/task/5392216174230064923) started by @pellared*