### PR TITLE
Security: Mask leading environment variables in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this library adheres to
   environment variables.
 - Add `cmd.ClearEnv` option to prevent environment inheritance in `cmd.Exec`.
 - Add `cmd.UnsetEnv` option to remove a specific environment variable in `cmd.Exec`.
+- Add `cmd.Mask` function which replaces the values of leading environment
+  variable assignments in a command line string with `[MASKED]`.
 
 ### Changed
 

--- a/build/helper.go
+++ b/build/helper.go
@@ -8,7 +8,7 @@ import (
 
 func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
 	a.Helper()
-	a.Log("Exec: ", cmdLine)
+	a.Log("Exec: ", cmd.Mask(cmdLine))
 	return cmd.Exec(a, cmdLine, opts...)
 }
 

--- a/build/security_test.go
+++ b/build/security_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestRunExec_Masking(t *testing.T) {
+	sb := &strings.Builder{}
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			runExec(a, "SECRET=password echo hello")
+		},
+	})
+
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = io.MultiWriter(in.Output, sb)
+			return next(in)
+		}
+	}
+	f.Use(mw)
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	if strings.Contains(got, "password") {
+		t.Errorf("Secret leaked in logs: %s", got)
+	}
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -48,6 +48,24 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	return true
 }
 
+// Mask replaces the values of leading environment variable assignments in a command line string with [MASKED].
+func Mask(cmdLine string) string {
+	envs, args, err := shellwords.ParseWithEnvs(cmdLine)
+	if err != nil {
+		return cmdLine
+	}
+	maskedEnvs := make([]string, len(envs))
+	for i, env := range envs {
+		split := strings.SplitN(env, "=", 2)
+		if len(split) == 2 {
+			maskedEnvs[i] = split[0] + "=[MASKED]"
+		} else {
+			maskedEnvs[i] = env
+		}
+	}
+	return strings.Join(append(maskedEnvs, args...), " ")
+}
+
 // Dir is an option to set the working directory.
 func Dir(s string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -56,8 +56,8 @@ func Mask(cmdLine string) string {
 	}
 	maskedEnvs := make([]string, len(envs))
 	for i, env := range envs {
-		split := strings.SplitN(env, "=", 2)
-		if len(split) == 2 {
+		split := strings.SplitN(env, "=", 2) //nolint:mnd // environment variable assignment
+		if len(split) == 2 {                 //nolint:mnd // environment variable assignment
 			maskedEnvs[i] = split[0] + "=[MASKED]"
 		} else {
 			maskedEnvs[i] = env

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -175,3 +175,54 @@ func TestExec_EnvOnly(t *testing.T) {
 	}()
 	Exec(&goyek.A{}, "FOO=bar")
 }
+
+func TestMask(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdLine string
+		want    string
+	}{
+		{
+			name:    "no env",
+			cmdLine: "echo hello",
+			want:    "echo hello",
+		},
+		{
+			name:    "single env",
+			cmdLine: "FOO=bar echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "multiple envs",
+			cmdLine: "FOO=bar BAZ=qux echo hello",
+			want:    "FOO=[MASKED] BAZ=[MASKED] echo hello",
+		},
+		{
+			name:    "env with spaces",
+			cmdLine: "FOO='bar baz' echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "no value env",
+			cmdLine: "FOO echo hello",
+			want:    "FOO echo hello",
+		},
+		{
+			name:    "empty command line",
+			cmdLine: "",
+			want:    "",
+		},
+		{
+			name:    "invalid command line",
+			cmdLine: "FOO='bar",
+			want:    "FOO='bar",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Mask(tt.cmdLine); got != tt.want {
+				t.Errorf("Mask() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/otelgoyek/otelgoyek_test.go
+++ b/otelgoyek/otelgoyek_test.go
@@ -16,11 +16,13 @@ import (
 	"github.com/goyek/x/otelgoyek"
 )
 
-const attrTaskOutput = "goyek.task.output"
-const traceparent = "00-0102030405060708090a0b0c0d0e0f10-0102030405060708-01"
-const spanNameExecute = "Execute"
-const taskNameTest = "test"
-const taskNamePanic = "panic"
+const (
+	attrTaskOutput  = "goyek.task.output"
+	traceparent     = "00-0102030405060708090a0b0c0d0e0f10-0102030405060708-01"
+	spanNameExecute = "Execute"
+	taskNameTest    = "test"
+	taskNamePanic   = "panic"
+)
 
 func TestMiddleware_WithDisableOutput(t *testing.T) {
 	exp, tp := setupOTel()
@@ -133,7 +135,7 @@ func TestExecutorMiddleware_ErrorTruncation(t *testing.T) {
 	)
 
 	next := func(_ goyek.ExecuteInput) error {
-		return fmt.Errorf("1234567890")
+		return errors.New("1234567890")
 	}
 
 	executor := mw(next)


### PR DESCRIPTION
This PR introduces a `cmd.Mask` function that replaces the values of leading environment variable assignments in a command line string with `[MASKED]`. This is a security enhancement to prevent sensitive information (like API keys or passwords) from being leaked into logs when a command line is logged.

The `build/helper.go` (which is used for the project's own build pipeline) has been updated to use `cmd.Mask` when logging executed commands.

Tests have been added to ensure that `cmd.Mask` works as expected and that the build helpers no longer leak secrets in their logs.

---
*PR created automatically by Jules for task [16815747954626199857](https://jules.google.com/task/16815747954626199857) started by @pellared*