### PR TITLE
Mask secrets in command line logs

### DIFF
--- a/build/helper.go
+++ b/build/helper.go
@@ -8,7 +8,7 @@ import (
 
 func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
 	a.Helper()
-	a.Log("Exec: ", cmdLine)
+	a.Log("Exec: ", cmd.Mask(cmdLine))
 	return cmd.Exec(a, cmdLine, opts...)
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -48,6 +48,25 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	return true
 }
 
+// Mask returns the command line with masked environment variables.
+// It is useful for logging the command line without leaking secrets.
+//
+// Example usage:
+//
+//	cmd.Mask("FOO=foo BAR=baz ./foo") // returns "FOO=[MASKED] BAR=[MASKED] ./foo"
+func Mask(cmdLine string) string {
+	envs, args, err := shellwords.ParseWithEnvs(cmdLine)
+	if err != nil || len(envs) == 0 {
+		return cmdLine
+	}
+	newEnvs := make([]string, len(envs))
+	for i, env := range envs {
+		kv := strings.SplitN(env, "=", 2)
+		newEnvs[i] = kv[0] + "=[MASKED]"
+	}
+	return strings.Join(append(newEnvs, args...), " ")
+}
+
 // Dir is an option to set the working directory.
 func Dir(s string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -61,7 +61,7 @@ func Mask(cmdLine string) string {
 	}
 	newEnvs := make([]string, len(envs))
 	for i, env := range envs {
-		kv := strings.SplitN(env, "=", 2)
+		kv := strings.SplitN(env, "=", 2) //nolint:mnd // splitting key-value pair
 		newEnvs[i] = kv[0] + "=[MASKED]"
 	}
 	return strings.Join(append(newEnvs, args...), " ")

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -175,3 +175,49 @@ func TestExec_EnvOnly(t *testing.T) {
 	}()
 	Exec(&goyek.A{}, "FOO=bar")
 }
+
+func TestMask(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdLine string
+		want    string
+	}{
+		{
+			name:    "no env",
+			cmdLine: "ls -l",
+			want:    "ls -l",
+		},
+		{
+			name:    "one env",
+			cmdLine: "FOO=bar ls -l",
+			want:    "FOO=[MASKED] ls -l",
+		},
+		{
+			name:    "multiple envs",
+			cmdLine: "FOO=bar BAZ=qux ls -l",
+			want:    "FOO=[MASKED] BAZ=[MASKED] ls -l",
+		},
+		{
+			name:    "quoted arguments",
+			cmdLine: "FOO=bar ./cmd \"arg 1\" 'arg 2'",
+			want:    "FOO=[MASKED] ./cmd arg 1 arg 2",
+		},
+		{
+			name:    "invalid command line",
+			cmdLine: "FOO='bar",
+			want:    "FOO='bar",
+		},
+		{
+			name:    "env only",
+			cmdLine: "FOO=bar",
+			want:    "FOO=[MASKED]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Mask(tt.cmdLine); got != tt.want {
+				t.Errorf("Mask() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/security_test.go
+++ b/cmd/security_test.go
@@ -50,3 +50,41 @@ func TestLogging_Security(t *testing.T) {
 		t.Errorf("Inline secret was logged: %s", got)
 	}
 }
+
+func TestMask_Security(t *testing.T) {
+	sb := &strings.Builder{}
+	// Simulated runExec from build/helper.go
+	runExec := func(a *goyek.A, cmdLine string) {
+		a.Log("Exec: ", Mask(cmdLine))
+	}
+
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = io.MultiWriter(in.Output, sb)
+			return next(in)
+		}
+	}
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			runExec(a, "PASSWORD=secret echo hello")
+		},
+	})
+
+	oldFlow := goyek.DefaultFlow
+	defer func() { goyek.DefaultFlow = oldFlow }()
+	goyek.DefaultFlow = f
+	goyek.Use(mw)
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	if strings.Contains(got, "secret") {
+		t.Errorf("Secret value was logged: %s", got)
+	}
+	if !strings.Contains(got, "PASSWORD=[MASKED]") {
+		t.Errorf("Secret was not masked in logs: %s", got)
+	}
+}

--- a/otelgoyek/otelgoyek_test.go
+++ b/otelgoyek/otelgoyek_test.go
@@ -16,11 +16,13 @@ import (
 	"github.com/goyek/x/otelgoyek"
 )
 
-const attrTaskOutput = "goyek.task.output"
-const traceparent = "00-0102030405060708090a0b0c0d0e0f10-0102030405060708-01"
-const spanNameExecute = "Execute"
-const taskNameTest = "test"
-const taskNamePanic = "panic"
+const (
+	attrTaskOutput  = "goyek.task.output"
+	traceparent     = "00-0102030405060708090a0b0c0d0e0f10-0102030405060708-01"
+	spanNameExecute = "Execute"
+	taskNameTest    = "test"
+	taskNamePanic   = "panic"
+)
 
 func TestMiddleware_WithDisableOutput(t *testing.T) {
 	exp, tp := setupOTel()
@@ -133,7 +135,7 @@ func TestExecutorMiddleware_ErrorTruncation(t *testing.T) {
 	)
 
 	next := func(_ goyek.ExecuteInput) error {
-		return fmt.Errorf("1234567890")
+		return errors.New("1234567890")
 	}
 
 	executor := mw(next)


### PR DESCRIPTION
I have implemented a security enhancement to prevent secret leakage in logs.

Key changes:
1.  **Added `cmd.Mask` function**: This function parses a command line string and replaces the values of any leading environment variable assignments with `[MASKED]`. It uses `github.com/mattn/go-shellwords` for robust parsing.
2.  **Updated `build/helper.go`**: Modified the `runExec` helper to use `cmd.Mask` when logging the command being executed.
3.  **Enhanced Testing**:
    *   Added unit tests for `cmd.Mask` in `cmd/cmd_test.go` covering various scenarios (multiple envs, quoted args, invalid strings).
    *   Added a security-focused test in `cmd/security_test.go` to verify that secrets are correctly masked in task logs.

This change ensures that commands like `DB_PASSWORD=secret ./migrate.sh` will be logged as `DB_PASSWORD=[MASKED] ./migrate.sh` while still executing with the actual secret.

---
*PR created automatically by Jules for task [7148030322603638078](https://jules.google.com/task/7148030322603638078) started by @pellared*