### PR TITLE
Mask secrets in command logs

### DIFF
--- a/build/helper.go
+++ b/build/helper.go
@@ -8,7 +8,7 @@ import (
 
 func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
 	a.Helper()
-	a.Log("Exec: ", cmdLine)
+	a.Log("Exec: ", cmd.Mask(cmdLine))
 	return cmd.Exec(a, cmdLine, opts...)
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -48,6 +48,27 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	return true
 }
 
+// Mask returns a masked command line string.
+// Leading environment variable assignments' values are replaced with [MASKED].
+func Mask(cmdLine string) string {
+	envs, args, err := shellwords.ParseWithEnvs(cmdLine)
+	if err != nil {
+		return cmdLine
+	}
+	if len(envs) == 0 {
+		return cmdLine
+	}
+	maskedEnvs := make([]string, len(envs))
+	for i, e := range envs {
+		if idx := strings.IndexByte(e, '='); idx != -1 {
+			maskedEnvs[i] = e[:idx+1] + "[MASKED]"
+		} else {
+			maskedEnvs[i] = e
+		}
+	}
+	return strings.Join(append(maskedEnvs, args...), " ")
+}
+
 // Dir is an option to set the working directory.
 func Dir(s string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -134,6 +134,58 @@ func TestExec_ClearEnv_WithEnv(t *testing.T) {
 	}
 }
 
+func TestMask(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdLine string
+		want    string
+	}{
+		{
+			name:    "no env vars",
+			cmdLine: "echo hello",
+			want:    "echo hello",
+		},
+		{
+			name:    "single env var",
+			cmdLine: "FOO=bar echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "multiple env vars",
+			cmdLine: "FOO=bar BAZ=qux echo hello",
+			want:    "FOO=[MASKED] BAZ=[MASKED] echo hello",
+		},
+		{
+			name:    "quoted values",
+			cmdLine: "FOO='bar baz' echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "mixed quotes",
+			cmdLine: "FOO=\"bar baz\" BAZ='qux' echo \"hello world\"",
+			want:    "FOO=[MASKED] BAZ=[MASKED] echo hello world",
+		},
+		{
+			name:    "no value",
+			cmdLine: "FOO echo hello",
+			want:    "FOO echo hello",
+		},
+		{
+			name:    "invalid command line",
+			cmdLine: "FOO='bar",
+			want:    "FOO='bar",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Mask(tt.cmdLine); got != tt.want {
+				t.Errorf("Mask() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExec_UnsetEnv(t *testing.T) {
 	t.Setenv("GOYEK_TEST_VAR", "present")
 	t.Setenv("ANOTHER_VAR", "stay")


### PR DESCRIPTION
This change introduces a security enhancement to prevent sensitive information from being leaked in build logs.

Key changes:
- Added `cmd.Mask(cmdLine string) string` to identify and mask leading environment variable assignments (e.g., `FOO=bar` becomes `FOO=[MASKED]`).
- Updated `build/helper.go`'s `runExec` to mask the command line before logging it.
- Added comprehensive unit tests for the `Mask` function in `cmd/cmd_test.go`.

This ensures that secrets passed as inline environment variables are sanitized in the output while maintaining the visibility of the command being executed.

---
*PR created automatically by Jules for task [2006843993687190856](https://jules.google.com/task/2006843993687190856) started by @pellared*