### PR TITLE
Implement command-line secret masking in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this library adheres to
   environment variables.
 - Add `cmd.ClearEnv` option to prevent environment inheritance in `cmd.Exec`.
 - Add `cmd.UnsetEnv` option to remove a specific environment variable in `cmd.Exec`.
+- Add `cmd.Mask` function that replaces the values of leading environment variable
+  assignments in a command line string with `[MASKED]` to prevent secret leakage
+  in logs.
 
 ### Changed
 

--- a/build/helper.go
+++ b/build/helper.go
@@ -8,7 +8,7 @@ import (
 
 func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
 	a.Helper()
-	a.Log("Exec: ", cmdLine)
+	a.Log("Exec: ", cmd.Mask(cmdLine))
 	return cmd.Exec(a, cmdLine, opts...)
 }
 

--- a/build/security_test.go
+++ b/build/security_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestRunExec_Security(t *testing.T) {
+	sb := &strings.Builder{}
+
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = io.MultiWriter(in.Output, sb)
+			return next(in)
+		}
+	}
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			runExec(a, "SECRET=password echo hello")
+		},
+	})
+	f.Use(mw)
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	if strings.Contains(got, "password") {
+		t.Errorf("Secret value from runExec was logged: %s", got)
+	}
+	if !strings.Contains(got, "SECRET=[MASKED]") {
+		t.Errorf("Secret was not masked in log: %s", got)
+	}
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -48,6 +48,24 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	return true
 }
 
+// Mask replaces the values of leading environment variable assignments with [MASKED].
+func Mask(cmdLine string) string {
+	envs, args, err := shellwords.ParseWithEnvs(cmdLine)
+	if err != nil || len(envs) == 0 {
+		return cmdLine
+	}
+	masked := make([]string, 0, len(envs)+len(args))
+	for _, env := range envs {
+		if k, _, ok := strings.Cut(env, "="); ok {
+			masked = append(masked, k+"=[MASKED]")
+		} else {
+			masked = append(masked, env+"=[MASKED]")
+		}
+	}
+	masked = append(masked, args...)
+	return strings.Join(masked, " ")
+}
+
 // Dir is an option to set the working directory.
 func Dir(s string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -175,3 +175,59 @@ func TestExec_EnvOnly(t *testing.T) {
 	}()
 	Exec(&goyek.A{}, "FOO=bar")
 }
+
+func TestMask(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdLine string
+		want    string
+	}{
+		{
+			name:    "no env",
+			cmdLine: "echo hello",
+			want:    "echo hello",
+		},
+		{
+			name:    "one env",
+			cmdLine: "FOO=bar echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "multiple envs",
+			cmdLine: "FOO=bar BAZ=qux echo hello",
+			want:    "FOO=[MASKED] BAZ=[MASKED] echo hello",
+		},
+		{
+			name:    "quoted env",
+			cmdLine: "FOO='bar baz' echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "quoted command",
+			cmdLine: "FOO=bar 'echo' hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "invalid",
+			cmdLine: "FOO='bar",
+			want:    "FOO='bar",
+		},
+		{
+			name:    "env only",
+			cmdLine: "FOO=bar",
+			want:    "FOO=[MASKED]",
+		},
+		{
+			name:    "no value",
+			cmdLine: "FOO= echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Mask(tt.cmdLine); got != tt.want {
+				t.Errorf("Mask() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change introduces a security enhancement to prevent the leakage of sensitive information (like API keys or passwords) when executing commands with inline environment variables.

Key changes:
1.  **`cmd.Mask`**: A new utility in the `cmd` package that parses a command-line string and replaces the values of leading environment variable assignments with `[MASKED]`.
2.  **Log Masking in `runExec`**: The `build` module's `runExec` helper now uses `cmd.Mask` before logging, ensuring that any secrets passed as inline environment variables in build tasks are redacted in the logs.
3.  **Comprehensive Testing**:
    *   Unit tests for `cmd.Mask` cover various scenarios, including multiple variables, quoted values, and invalid command lines.
    *   A new regression test in `build/security_test.go` verifies that `runExec` correctly masks secrets in its output.

This enhancement aligns with security best practices for CI/CD and build pipelines by minimizing the risk of accidental secret exposure.

---
*PR created automatically by Jules for task [2577530394679198038](https://jules.google.com/task/2577530394679198038) started by @pellared*