### PR TITLE
Add command-line masking to prevent secret leakage in logs

### DIFF
--- a/build/helper.go
+++ b/build/helper.go
@@ -8,7 +8,7 @@ import (
 
 func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
 	a.Helper()
-	a.Log("Exec: ", cmdLine)
+	a.Log("Exec: ", cmd.Mask(cmdLine))
 	return cmd.Exec(a, cmdLine, opts...)
 }
 

--- a/build/security_test.go
+++ b/build/security_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestRunExec_Masking(t *testing.T) {
+	var sb strings.Builder
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			runExec(a, "SECRET=password echo hello")
+		},
+	})
+
+	// Use a middleware to capture the output
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = io.MultiWriter(in.Output, &sb)
+			return next(in)
+		}
+	}
+	f.Use(mw)
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	if strings.Contains(got, "password") {
+		t.Errorf("Secret value was logged: %s", got)
+	}
+	if !strings.Contains(got, "SECRET=[MASKED]") {
+		t.Errorf("Secret was not masked: %s", got)
+	}
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -109,3 +109,20 @@ func Stderr(w io.Writer) Option {
 		cmd.Stderr = w
 	}
 }
+
+// Mask returns the command line string with leading environment variable
+// values replaced with [MASKED].
+func Mask(cmdLine string) string {
+	envs, args, err := shellwords.ParseWithEnvs(cmdLine)
+	if err != nil || len(envs) == 0 {
+		return cmdLine
+	}
+	var sb strings.Builder
+	for _, env := range envs {
+		split := strings.SplitN(env, "=", 2)
+		sb.WriteString(split[0])
+		sb.WriteString("=[MASKED] ")
+	}
+	sb.WriteString(strings.Join(args, " "))
+	return sb.String()
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -119,7 +119,7 @@ func Mask(cmdLine string) string {
 	}
 	var sb strings.Builder
 	for _, env := range envs {
-		split := strings.SplitN(env, "=", 2)
+		split := strings.SplitN(env, "=", 2) //nolint:mnd // split into key and value
 		sb.WriteString(split[0])
 		sb.WriteString("=[MASKED] ")
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -175,3 +175,51 @@ func TestExec_EnvOnly(t *testing.T) {
 	}()
 	Exec(&goyek.A{}, "FOO=bar")
 }
+
+func TestMask(t *testing.T) {
+	tc := []struct {
+		name    string
+		cmdLine string
+		want    string
+	}{
+		{
+			name:    "empty",
+			cmdLine: "",
+			want:    "",
+		},
+		{
+			name:    "no env vars",
+			cmdLine: "echo hello",
+			want:    "echo hello",
+		},
+		{
+			name:    "one env var",
+			cmdLine: "FOO=bar echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "multiple env vars",
+			cmdLine: "FOO=bar BAZ=qux echo hello",
+			want:    "FOO=[MASKED] BAZ=[MASKED] echo hello",
+		},
+		{
+			name:    "invalid",
+			cmdLine: "FOO='",
+			want:    "FOO='",
+		},
+		{
+			name:    "only env var",
+			cmdLine: "FOO=bar",
+			want:    "FOO=[MASKED] ",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Mask(tt.cmdLine)
+			if got != tt.want {
+				t.Errorf("Mask(%q) = %q, want %q", tt.cmdLine, got, tt.want)
+			}
+		})
+	}
+}

--- a/otelgoyek/otelgoyek_test.go
+++ b/otelgoyek/otelgoyek_test.go
@@ -16,11 +16,13 @@ import (
 	"github.com/goyek/x/otelgoyek"
 )
 
-const attrTaskOutput = "goyek.task.output"
-const traceparent = "00-0102030405060708090a0b0c0d0e0f10-0102030405060708-01"
-const spanNameExecute = "Execute"
-const taskNameTest = "test"
-const taskNamePanic = "panic"
+const (
+	attrTaskOutput  = "goyek.task.output"
+	traceparent     = "00-0102030405060708090a0b0c0d0e0f10-0102030405060708-01"
+	spanNameExecute = "Execute"
+	taskNameTest    = "test"
+	taskNamePanic   = "panic"
+)
 
 func TestMiddleware_WithDisableOutput(t *testing.T) {
 	exp, tp := setupOTel()
@@ -133,7 +135,7 @@ func TestExecutorMiddleware_ErrorTruncation(t *testing.T) {
 	)
 
 	next := func(_ goyek.ExecuteInput) error {
-		return fmt.Errorf("1234567890")
+		return errors.New("1234567890")
 	}
 
 	executor := mw(next)


### PR DESCRIPTION
I have implemented a security enhancement to protect sensitive information in logs.

### Security Issue
The `runExec` helper in the `build` package was logging the full command line before execution. When environment variables containing secrets were passed inline (e.g., `SECRET=password echo hello`), these secrets were being leaked into the build logs.

### Enhancement
1.  **New `cmd.Mask` Function**: I added a `Mask` function to the `cmd` package. This function uses `shellwords.ParseWithEnvs` to identify leading environment variable assignments and replaces their values with `[MASKED]`.
2.  **Log Sanitization**: I updated `runExec` in `build/helper.go` to wrap the command line with `cmd.Mask` before logging it.
3.  **Comprehensive Testing**:
    *   Added unit tests for `cmd.Mask` covering various scenarios (multiple variables, no variables, invalid commands).
    *   Added a regression test in `build/security_test.go` that verifies that `runExec` correctly masks secrets when running a task.

This change ensures that even if developers pass secrets via inline environment variables, they won't be exposed in the build output.

---
*PR created automatically by Jules for task [8361327657718553089](https://jules.google.com/task/8361327657718553089) started by @pellared*