### PR TITLE
Mask secrets in command line logs

### DIFF
--- a/build/helper.go
+++ b/build/helper.go
@@ -8,7 +8,7 @@ import (
 
 func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
 	a.Helper()
-	a.Log("Exec: ", cmdLine)
+	a.Log("Exec: ", cmd.Mask(cmdLine))
 	return cmd.Exec(a, cmdLine, opts...)
 }
 

--- a/build/security_test.go
+++ b/build/security_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestRunExec_Masking(t *testing.T) {
+	sb := &strings.Builder{}
+
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = io.MultiWriter(in.Output, sb)
+			return next(in)
+		}
+	}
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			runExec(a, "SECRET=password echo hello")
+		},
+	})
+	f.Use(mw)
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	if strings.Contains(got, "password") {
+		t.Errorf("Secret value was logged: %s", got)
+	}
+	if !strings.Contains(got, "SECRET=[MASKED]") {
+		t.Errorf("Secret value was not masked in logs: %s", got)
+	}
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -109,3 +109,26 @@ func Stderr(w io.Writer) Option {
 		cmd.Stderr = w
 	}
 }
+
+// Mask returns the command line with leading environment variable values masked.
+func Mask(cmdLine string) string {
+	envs, args, err := shellwords.ParseWithEnvs(cmdLine)
+	if err != nil || (len(envs) == 0 && len(args) == 0) {
+		return cmdLine
+	}
+
+	masked := make([]string, 0, len(envs)+len(args))
+	for _, env := range envs {
+		split := strings.SplitN(env, "=", 2)
+		masked = append(masked, split[0]+"=[MASKED]")
+	}
+
+	for _, arg := range args {
+		if strings.Contains(arg, " ") {
+			arg = "'" + arg + "'"
+		}
+		masked = append(masked, arg)
+	}
+
+	return strings.Join(masked, " ")
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -119,7 +119,7 @@ func Mask(cmdLine string) string {
 
 	masked := make([]string, 0, len(envs)+len(args))
 	for _, env := range envs {
-		split := strings.SplitN(env, "=", 2)
+		split := strings.SplitN(env, "=", 2) //nolint:mnd // environment variable key-value pair
 		masked = append(masked, split[0]+"=[MASKED]")
 	}
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -175,3 +175,59 @@ func TestExec_EnvOnly(t *testing.T) {
 	}()
 	Exec(&goyek.A{}, "FOO=bar")
 }
+
+func TestMask(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdLine string
+		want    string
+	}{
+		{
+			name:    "empty",
+			cmdLine: "",
+			want:    "",
+		},
+		{
+			name:    "no env",
+			cmdLine: "echo hello",
+			want:    "echo hello",
+		},
+		{
+			name:    "one env",
+			cmdLine: "FOO=bar echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "multiple envs",
+			cmdLine: "FOO=bar BAZ=qux echo hello",
+			want:    "FOO=[MASKED] BAZ=[MASKED] echo hello",
+		},
+		{
+			name:    "env with space",
+			cmdLine: "FOO='bar baz' echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "arg with space",
+			cmdLine: "echo 'hello world'",
+			want:    "echo 'hello world'",
+		},
+		{
+			name:    "complex",
+			cmdLine: "FOO=bar BAZ='qux quux' ./script.sh --arg='some value'",
+			want:    "FOO=[MASKED] BAZ=[MASKED] ./script.sh '--arg=some value'",
+		},
+		{
+			name:    "invalid",
+			cmdLine: "echo 'hello",
+			want:    "echo 'hello",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Mask(tt.cmdLine); got != tt.want {
+				t.Errorf("Mask() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implemented a `cmd.Mask` utility to sanitize command lines by masking leading environment variable assignments. Updated the build pipeline's `runExec` helper to use this utility, preventing sensitive information from being logged. Added comprehensive unit tests and a regression test to ensure correctness and prevent future leaks.

---
*PR created automatically by Jules for task [17300336400551721334](https://jules.google.com/task/17300336400551721334) started by @pellared*