### PR TITLE
Mask secrets in command line logs

### DIFF
--- a/build/helper.go
+++ b/build/helper.go
@@ -8,7 +8,7 @@ import (
 
 func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
 	a.Helper()
-	a.Log("Exec: ", cmdLine)
+	a.Log("Exec: ", cmd.Mask(cmdLine))
 	return cmd.Exec(a, cmdLine, opts...)
 }
 

--- a/build/security_test.go
+++ b/build/security_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestRunExec_Security(t *testing.T) {
+	sb := &strings.Builder{}
+
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = io.MultiWriter(in.Output, sb)
+			return next(in)
+		}
+	}
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			runExec(a, "SECRET=password echo hello")
+		},
+	})
+
+	oldFlow := goyek.DefaultFlow
+	defer func() { goyek.DefaultFlow = oldFlow }()
+	goyek.DefaultFlow = f
+	goyek.Use(mw)
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	if strings.Contains(got, "password") {
+		t.Errorf("Secret value from runExec was logged: %s", got)
+	}
+	if !strings.Contains(got, "SECRET=[MASKED]") {
+		t.Errorf("Secret value was not masked in logs: %s", got)
+	}
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -56,7 +56,7 @@ func Mask(cmdLine string) string {
 	}
 	maskedEnvs := make([]string, len(envs))
 	for i, env := range envs {
-		split := strings.SplitN(env, "=", 2)
+		split := strings.SplitN(env, "=", 2) //nolint:mnd // it is used to split key and value
 		maskedEnvs[i] = split[0] + "=[MASKED]"
 	}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -48,6 +48,30 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	return true
 }
 
+// Mask replaces the values of leading environment variable assignments with [MASKED].
+func Mask(cmdLine string) string {
+	envs, args, err := shellwords.ParseWithEnvs(cmdLine)
+	if err != nil || len(envs) == 0 {
+		return cmdLine
+	}
+	maskedEnvs := make([]string, len(envs))
+	for i, env := range envs {
+		split := strings.SplitN(env, "=", 2)
+		maskedEnvs[i] = split[0] + "=[MASKED]"
+	}
+
+	resArgs := make([]string, 0, len(maskedEnvs)+len(args))
+	resArgs = append(resArgs, maskedEnvs...)
+	for _, arg := range args {
+		if strings.Contains(arg, " ") {
+			resArgs = append(resArgs, "'"+arg+"'")
+		} else {
+			resArgs = append(resArgs, arg)
+		}
+	}
+	return strings.Join(resArgs, " ")
+}
+
 // Dir is an option to set the working directory.
 func Dir(s string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -175,3 +175,54 @@ func TestExec_EnvOnly(t *testing.T) {
 	}()
 	Exec(&goyek.A{}, "FOO=bar")
 }
+
+func TestMask(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdLine string
+		want    string
+	}{
+		{
+			name:    "empty",
+			cmdLine: "",
+			want:    "",
+		},
+		{
+			name:    "no env vars",
+			cmdLine: "ls -l",
+			want:    "ls -l",
+		},
+		{
+			name:    "one env var",
+			cmdLine: "FOO=bar ls -l",
+			want:    "FOO=[MASKED] ls -l",
+		},
+		{
+			name:    "multiple env vars",
+			cmdLine: "FOO=bar BAZ=qux ls -l",
+			want:    "FOO=[MASKED] BAZ=[MASKED] ls -l",
+		},
+		{
+			name:    "env var with space",
+			cmdLine: "FOO='bar baz' ls -l",
+			want:    "FOO=[MASKED] ls -l",
+		},
+		{
+			name:    "command with space",
+			cmdLine: "FOO=bar ./my cmd --arg='val val'",
+			want:    "FOO=[MASKED] ./my cmd '--arg=val val'",
+		},
+		{
+			name:    "invalid command line",
+			cmdLine: "FOO='bar",
+			want:    "FOO='bar",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Mask(tt.cmdLine); got != tt.want {
+				t.Errorf("Mask() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Identified a security risk where secrets passed via inline environment variables in `runExec` would be logged in plain text.
Implemented `cmd.Mask` to sanitize these command lines for logging purposes.
Updated the build helper to use the new masking functionality.
Added unit and integration tests to ensure correct behavior and prevent regressions.

---
*PR created automatically by Jules for task [2825281040025120950](https://jules.google.com/task/2825281040025120950) started by @pellared*