### PR TITLE
Mask environment variable values in logs

### DIFF
--- a/build/helper.go
+++ b/build/helper.go
@@ -8,7 +8,7 @@ import (
 
 func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
 	a.Helper()
-	a.Log("Exec: ", cmdLine)
+	a.Log("Exec: ", cmd.Mask(cmdLine))
 	return cmd.Exec(a, cmdLine, opts...)
 }
 

--- a/build/security_test.go
+++ b/build/security_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestRunExec_Security(t *testing.T) {
+	sb := &strings.Builder{}
+
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = io.MultiWriter(in.Output, sb)
+			return next(in)
+		}
+	}
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			runExec(a, "SECRET=password echo hello")
+		},
+	})
+	f.Use(mw)
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	if strings.Contains(got, "password") {
+		t.Errorf("Secret value from runExec was logged: %s", got)
+	}
+	if !strings.Contains(got, "SECRET=[MASKED]") {
+		t.Errorf("Expected masked secret in logs, but got: %s", got)
+	}
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -11,6 +11,29 @@ import (
 	"github.com/mattn/go-shellwords"
 )
 
+// Mask replaces the values of leading environment variable assignments with [MASKED].
+// It is intended for logging command lines that may contain secrets.
+// It returns the original command line if it cannot be parsed or if no environment variables are present.
+func Mask(cmdLine string) string {
+	envs, args, err := shellwords.ParseWithEnvs(cmdLine)
+	if err != nil || len(envs) == 0 {
+		return cmdLine
+	}
+
+	masked := make([]string, 0, len(envs)+len(args))
+	for _, env := range envs {
+		split := strings.SplitN(env, "=", 2) //nolint:mnd // standard split
+		masked = append(masked, split[0]+"=[MASKED]")
+	}
+	for _, arg := range args {
+		if strings.Contains(arg, " ") {
+			arg = "'" + arg + "'"
+		}
+		masked = append(masked, arg)
+	}
+	return strings.Join(masked, " ")
+}
+
 // Option configures the command.
 type Option func(a *goyek.A, cmd *exec.Cmd)
 

--- a/cmd/security_test.go
+++ b/cmd/security_test.go
@@ -50,3 +50,55 @@ func TestLogging_Security(t *testing.T) {
 		t.Errorf("Inline secret was logged: %s", got)
 	}
 }
+
+func TestMask(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdLine string
+		want    string
+	}{
+		{
+			name:    "no env vars",
+			cmdLine: "echo hello",
+			want:    "echo hello",
+		},
+		{
+			name:    "one env var",
+			cmdLine: "FOO=bar echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "multiple env vars",
+			cmdLine: "FOO=bar BAZ=qux echo hello",
+			want:    "FOO=[MASKED] BAZ=[MASKED] echo hello",
+		},
+		{
+			name:    "env var with space",
+			cmdLine: "FOO='bar baz' echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "argument with space",
+			cmdLine: "echo 'hello world'",
+			want:    "echo 'hello world'",
+		},
+		{
+			name:    "malformed",
+			cmdLine: "echo 'hello",
+			want:    "echo 'hello",
+		},
+		{
+			name:    "empty",
+			cmdLine: "",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Mask(tt.cmdLine); got != tt.want {
+				t.Errorf("Mask() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implemented a security enhancement that masks sensitive environment variable values when logging command lines.

Key changes:
- Added `cmd.Mask(cmdLine string) string` utility that uses `shellwords` to parse and sanitize inline environment variables.
- Updated `runExec` in `build/helper.go` to use `cmd.Mask` for its logging output.
- Added comprehensive tests in `cmd/security_test.go` and `build/security_test.go` to verify the masking logic and its integration.
- Added a `nolint:mnd` directive to `cmd/cmd.go` to comply with project linting rules.

---
*PR created automatically by Jules for task [4955053604779549119](https://jules.google.com/task/4955053604779549119) started by @pellared*