### PR TITLE
Mask inline environment variables in command logs

### DIFF
--- a/build/helper.go
+++ b/build/helper.go
@@ -8,7 +8,7 @@ import (
 
 func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
 	a.Helper()
-	a.Log("Exec: ", cmdLine)
+	a.Log("Exec: ", cmd.Mask(cmdLine))
 	return cmd.Exec(a, cmdLine, opts...)
 }
 

--- a/build/security_test.go
+++ b/build/security_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestRunExec_Security(t *testing.T) {
+	sb := &strings.Builder{}
+
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = io.MultiWriter(in.Output, sb)
+			return next(in)
+		}
+	}
+
+	f := &goyek.Flow{}
+	f.Use(mw)
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			runExec(a, "SECRET=password echo hello")
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	if strings.Contains(got, "password") {
+		t.Errorf("Secret value from runExec was logged: %s", got)
+	}
+	if !strings.Contains(got, "SECRET=[MASKED]") {
+		t.Errorf("Inline secret was not masked in logs: %s", got)
+	}
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -48,6 +48,28 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	return true
 }
 
+// Mask replaces the values of leading environment variable assignments in a command line string with [MASKED].
+func Mask(cmdLine string) string {
+	envs, args, err := shellwords.ParseWithEnvs(cmdLine)
+	if err != nil || len(envs) == 0 {
+		return cmdLine
+	}
+
+	res := make([]string, 0, len(envs)+len(args))
+	for _, env := range envs {
+		key, _, _ := strings.Cut(env, "=")
+		res = append(res, key+"=[MASKED]")
+	}
+	for _, arg := range args {
+		if strings.Contains(arg, " ") {
+			res = append(res, "'"+arg+"'")
+		} else {
+			res = append(res, arg)
+		}
+	}
+	return strings.Join(res, " ")
+}
+
 // Dir is an option to set the working directory.
 func Dir(s string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -175,3 +175,59 @@ func TestExec_EnvOnly(t *testing.T) {
 	}()
 	Exec(&goyek.A{}, "FOO=bar")
 }
+
+func TestMask(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdLine string
+		want    string
+	}{
+		{
+			name:    "no env",
+			cmdLine: "echo hello",
+			want:    "echo hello",
+		},
+		{
+			name:    "one env",
+			cmdLine: "FOO=bar echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "multiple envs",
+			cmdLine: "FOO=bar BAZ=qux echo hello",
+			want:    "FOO=[MASKED] BAZ=[MASKED] echo hello",
+		},
+		{
+			name:    "multiple envs with spaces",
+			cmdLine: "FOO='bar baz' BAZ=\"qux quux\" echo hello",
+			want:    "FOO=[MASKED] BAZ=[MASKED] echo hello",
+		},
+		{
+			name:    "command with spaces",
+			cmdLine: "FOO=bar ./my\\ script hello",
+			want:    "FOO=[MASKED] './my script' hello",
+		},
+		{
+			name:    "empty",
+			cmdLine: "",
+			want:    "",
+		},
+		{
+			name:    "only env",
+			cmdLine: "FOO=bar",
+			want:    "FOO=[MASKED]",
+		},
+		{
+			name:    "invalid",
+			cmdLine: "FOO='bar",
+			want:    "FOO='bar",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Mask(tt.cmdLine); got != tt.want {
+				t.Errorf("Mask() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a security enhancement to prevent sensitive information from being leaked into logs when running commands with inline environment variables.

Key changes:
- Added `cmd.Mask` function to the `cmd` package which identifies leading environment variable assignments and masks their values.
- Updated `build/helper.go`'s `runExec` to use `cmd.Mask` before logging the command being executed.
- Added comprehensive unit tests for `cmd.Mask` in `cmd/cmd_test.go`.
- Added a regression test in `build/security_test.go` to ensure `runExec` correctly masks secrets.

This ensures that while the commands are executed with the necessary secrets, the logs only show that a secret was present without revealing its value.

---
*PR created automatically by Jules for task [12594121193051140084](https://jules.google.com/task/12594121193051140084) started by @pellared*