### PR TITLE
Mask secrets in build logs

### DIFF
--- a/build/helper.go
+++ b/build/helper.go
@@ -8,7 +8,7 @@ import (
 
 func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
 	a.Helper()
-	a.Log("Exec: ", cmdLine)
+	a.Log("Exec: ", cmd.Mask(cmdLine))
 	return cmd.Exec(a, cmdLine, opts...)
 }
 

--- a/build/security_test.go
+++ b/build/security_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestRunExec_Security(t *testing.T) {
+	sb := &strings.Builder{}
+
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = io.MultiWriter(in.Output, sb)
+			return next(in)
+		}
+	}
+
+	f := &goyek.Flow{}
+	f.Use(mw)
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			runExec(a, "SECRET=password echo hello")
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	if strings.Contains(got, "password") {
+		t.Errorf("Secret value was logged: %s", got)
+	}
+	if !strings.Contains(got, "SECRET=[MASKED]") {
+		t.Errorf("Secret was not masked: %s", got)
+	}
+}

--- a/cmd/mask.go
+++ b/cmd/mask.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/mattn/go-shellwords"
+)
+
+// Mask replaces the values of leading environment variable assignments with [MASKED].
+func Mask(cmdLine string) string {
+	envs, args, err := shellwords.ParseWithEnvs(cmdLine)
+	if err != nil || len(envs) == 0 {
+		return cmdLine
+	}
+
+	var sb strings.Builder
+	for _, env := range envs {
+		k, _, found := strings.Cut(env, "=")
+		if found {
+			sb.WriteString(k)
+			sb.WriteString("=[MASKED] ")
+		} else {
+			sb.WriteString(env)
+			sb.WriteString(" ")
+		}
+	}
+
+	for i, arg := range args {
+		if i > 0 {
+			sb.WriteString(" ")
+		}
+		if strings.Contains(arg, " ") {
+			sb.WriteString("'")
+			sb.WriteString(arg)
+			sb.WriteString("'")
+		} else {
+			sb.WriteString(arg)
+		}
+	}
+
+	return sb.String()
+}

--- a/cmd/mask_test.go
+++ b/cmd/mask_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import "testing"
+
+func TestMask(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdLine string
+		want    string
+	}{
+		{
+			name:    "no env vars",
+			cmdLine: "echo hello",
+			want:    "echo hello",
+		},
+		{
+			name:    "one env var",
+			cmdLine: "FOO=bar echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "multiple env vars",
+			cmdLine: "FOO=bar BAZ=qux echo hello",
+			want:    "FOO=[MASKED] BAZ=[MASKED] echo hello",
+		},
+		{
+			name:    "env var with space",
+			cmdLine: "FOO='bar baz' echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "arg with space",
+			cmdLine: "echo 'hello world'",
+			want:    "echo 'hello world'",
+		},
+		{
+			name:    "complex",
+			cmdLine: "FOO=bar ./script --arg='some value'",
+			want:    "FOO=[MASKED] ./script '--arg=some value'",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Mask(tt.cmdLine); got != tt.want {
+				t.Errorf("Mask() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces a security enhancement to prevent secret leakage in build logs.

Key changes:
- Added `cmd.Mask` function in `cmd/mask.go` to sanitize command-line strings by masking leading environment variable assignments.
- Updated `runExec` in `build/helper.go` to use `cmd.Mask` when logging commands.
- Added unit tests for `cmd.Mask` in `cmd/mask_test.go`.
- Added an integration/security test in `build/security_test.go` to ensure `runExec` correctly masks secrets in practice.
- Updated `go.mod` and `go.sum` to include the `github.com/mattn/go-shellwords` dependency (which was already used but not explicitly listed in the root `go.mod` in a way that satisfied all modules).

The core masking logic uses `github.com/mattn/go-shellwords` for robust shell-like parsing, ensuring that quoted values and complex command lines are handled correctly. Actual command execution remains unaffected as the unmasked command line is still passed to `cmd.Exec`.

---
*PR created automatically by Jules for task [17683059294211091784](https://jules.google.com/task/17683059294211091784) started by @pellared*