### PR TITLE
Mask environment variable secrets in command-line logs

### DIFF
--- a/build/helper.go
+++ b/build/helper.go
@@ -8,7 +8,7 @@ import (
 
 func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
 	a.Helper()
-	a.Log("Exec: ", cmdLine)
+	a.Log("Exec: ", cmd.Mask(cmdLine))
 	return cmd.Exec(a, cmdLine, opts...)
 }
 

--- a/build/security_test.go
+++ b/build/security_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestRunExec_Masking(t *testing.T) {
+	var sb strings.Builder
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = &sb
+			return next(in)
+		}
+	}
+
+	f := &goyek.Flow{}
+	f.Use(mw)
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			runExec(a, "SECRET=password echo hello")
+		},
+	})
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	if strings.Contains(got, "password") {
+		t.Errorf("Secret value was logged: %s", got)
+	}
+	if !strings.Contains(got, "SECRET=[MASKED]") {
+		t.Errorf("Secret was not masked: %s", got)
+	}
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -48,6 +48,37 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	return true
 }
 
+// Mask returns a command line string where the values of leading environment variables are masked.
+func Mask(cmdLine string) string {
+	envs, args, err := shellwords.ParseWithEnvs(cmdLine)
+	if err != nil || (len(envs) == 0 && len(args) == 0) {
+		return cmdLine
+	}
+
+	var sb strings.Builder
+	for _, env := range envs {
+		if sb.Len() > 0 {
+			sb.WriteByte(' ')
+		}
+		k, _, _ := strings.Cut(env, "=")
+		sb.WriteString(k)
+		sb.WriteString("=[MASKED]")
+	}
+	for _, arg := range args {
+		if sb.Len() > 0 {
+			sb.WriteByte(' ')
+		}
+		if strings.Contains(arg, " ") {
+			sb.WriteByte('"')
+			sb.WriteString(arg)
+			sb.WriteByte('"')
+		} else {
+			sb.WriteString(arg)
+		}
+	}
+	return sb.String()
+}
+
 // Dir is an option to set the working directory.
 func Dir(s string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -175,3 +175,61 @@ func TestExec_EnvOnly(t *testing.T) {
 	}()
 	Exec(&goyek.A{}, "FOO=bar")
 }
+
+func TestMask(t *testing.T) {
+	testCases := []struct {
+		name    string
+		cmdLine string
+		want    string
+	}{
+		{
+			name:    "empty",
+			cmdLine: "",
+			want:    "",
+		},
+		{
+			name:    "no env",
+			cmdLine: "ls -l",
+			want:    "ls -l",
+		},
+		{
+			name:    "one env",
+			cmdLine: "FOO=bar ls -l",
+			want:    "FOO=[MASKED] ls -l",
+		},
+		{
+			name:    "multiple envs",
+			cmdLine: "FOO=bar BAZ=qux ls -l",
+			want:    "FOO=[MASKED] BAZ=[MASKED] ls -l",
+		},
+		{
+			name:    "multiple envs with spaces",
+			cmdLine: "FOO=bar BAZ=\"qux quux\" ls -l",
+			want:    "FOO=[MASKED] BAZ=[MASKED] ls -l",
+		},
+		{
+			name:    "arg with spaces",
+			cmdLine: "echo \"hello world\"",
+			want:    "echo \"hello world\"",
+		},
+		{
+			name:    "env and arg with spaces",
+			cmdLine: "SECRET=password echo \"hello world\"",
+			want:    "SECRET=[MASKED] echo \"hello world\"",
+		},
+		{
+			name:    "invalid command line",
+			cmdLine: "echo \"hello",
+			want:    "echo \"hello",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Mask(tc.cmdLine)
+			if got != tc.want {
+				t.Errorf("Mask(%q) = %q, want %q", tc.cmdLine, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implement secret masking for command-line logs to prevent sensitive information (e.g., API keys, passwords) passed as environment variables from being exposed in build logs. This includes a new `cmd.Mask` function and its integration into the project's build helpers.

---
*PR created automatically by Jules for task [3333875199693607752](https://jules.google.com/task/3333875199693607752) started by @pellared*