### PR TITLE
Mask secrets in command line logs

### DIFF
--- a/build/helper.go
+++ b/build/helper.go
@@ -8,7 +8,7 @@ import (
 
 func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
 	a.Helper()
-	a.Log("Exec: ", cmdLine)
+	a.Log("Exec: ", cmd.Mask(cmdLine))
 	return cmd.Exec(a, cmdLine, opts...)
 }
 

--- a/build/security_test.go
+++ b/build/security_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestRunExec_Masking(t *testing.T) {
+	sb := &strings.Builder{}
+
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = io.MultiWriter(in.Output, sb)
+			return next(in)
+		}
+	}
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			runExec(a, "SECRET=password echo hello")
+		},
+	})
+
+	f.Use(mw)
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	if strings.Contains(got, "password") {
+		t.Errorf("Secret value was logged: %s", got)
+	}
+	if !strings.Contains(got, "SECRET=[MASKED]") {
+		t.Errorf("Secret was not masked in log: %s", got)
+	}
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -48,6 +48,43 @@ func Exec(a *goyek.A, cmdLine string, opts ...Option) bool {
 	return true
 }
 
+// Mask returns the command line string with masked environment variables.
+func Mask(cmdLine string) string {
+	envs, args, err := shellwords.ParseWithEnvs(cmdLine)
+	if err != nil || (len(envs) == 0 && len(args) == 0) {
+		return cmdLine
+	}
+
+	var sb strings.Builder
+	for _, env := range envs {
+		if sb.Len() > 0 {
+			sb.WriteByte(' ')
+		}
+		key, _, found := strings.Cut(env, "=")
+		if found {
+			sb.WriteString(key)
+			sb.WriteString("=[MASKED]")
+		} else {
+			sb.WriteString(env)
+		}
+	}
+
+	for _, arg := range args {
+		if sb.Len() > 0 {
+			sb.WriteByte(' ')
+		}
+		if strings.Contains(arg, " ") {
+			sb.WriteByte('"')
+			sb.WriteString(arg)
+			sb.WriteByte('"')
+		} else {
+			sb.WriteString(arg)
+		}
+	}
+
+	return sb.String()
+}
+
 // Dir is an option to set the working directory.
 func Dir(s string) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -175,3 +175,59 @@ func TestExec_EnvOnly(t *testing.T) {
 	}()
 	Exec(&goyek.A{}, "FOO=bar")
 }
+
+func TestMask(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdLine string
+		want    string
+	}{
+		{
+			name:    "no env vars",
+			cmdLine: "echo hello",
+			want:    "echo hello",
+		},
+		{
+			name:    "one env var",
+			cmdLine: "FOO=bar echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "multiple env vars",
+			cmdLine: "FOO=bar BAZ=qux echo hello",
+			want:    "FOO=[MASKED] BAZ=[MASKED] echo hello",
+		},
+		{
+			name:    "env var with spaces",
+			cmdLine: `FOO="bar baz" echo hello`,
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "argument with spaces",
+			cmdLine: `echo "hello world"`,
+			want:    `echo "hello world"`,
+		},
+		{
+			name:    "empty command",
+			cmdLine: "",
+			want:    "",
+		},
+		{
+			name:    "only env vars",
+			cmdLine: "FOO=bar",
+			want:    "FOO=[MASKED]",
+		},
+		{
+			name:    "parsing error",
+			cmdLine: `echo "unfinished quote`,
+			want:    `echo "unfinished quote`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Mask(tt.cmdLine); got != tt.want {
+				t.Errorf("Mask() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/security_test.go
+++ b/cmd/security_test.go
@@ -29,10 +29,7 @@ func TestLogging_Security(t *testing.T) {
 		},
 	})
 
-	oldFlow := goyek.DefaultFlow
-	defer func() { goyek.DefaultFlow = oldFlow }()
-	goyek.DefaultFlow = f
-	goyek.Use(mw)
+	f.Use(mw)
 
 	_ = f.Execute(context.Background(), []string{"test"})
 


### PR DESCRIPTION
This PR introduces a `Mask` function to the `cmd` package, which is designed to sanitize command-line strings by replacing the values of leading environment variable assignments with `[MASKED]`. This prevents sensitive information from being accidentally leaked into build logs or other output channels.

Key changes:
- Added `cmd.Mask(cmdLine string) string` in `cmd/cmd.go`.
- Integrated `cmd.Mask` into `runExec` in `build/helper.go`.
- Added unit tests for `cmd.Mask` in `cmd/cmd_test.go`.
- Added a regression test in `build/security_test.go`.
- Refactored `cmd/security_test.go` and `build/security_test.go` to use `f.Use(mw)` instead of `goyek.Use(mw)` for better test isolation.

---
*PR created automatically by Jules for task [2070796532455031007](https://jules.google.com/task/2070796532455031007) started by @pellared*