### PR TITLE
Mask environment variables in build logs to prevent secret leakage

### DIFF
--- a/build/helper.go
+++ b/build/helper.go
@@ -8,7 +8,7 @@ import (
 
 func runExec(a *goyek.A, cmdLine string, opts ...cmd.Option) bool {
 	a.Helper()
-	a.Log("Exec: ", cmdLine)
+	a.Log("Exec: ", cmd.Mask(cmdLine))
 	return cmd.Exec(a, cmdLine, opts...)
 }
 

--- a/build/security_test.go
+++ b/build/security_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goyek/goyek/v3"
+)
+
+func TestRunExec_Security(t *testing.T) {
+	sb := &strings.Builder{}
+
+	mw := func(next goyek.Runner) goyek.Runner {
+		return func(in goyek.Input) goyek.Result {
+			in.Output = io.MultiWriter(in.Output, sb)
+			return next(in)
+		}
+	}
+
+	f := &goyek.Flow{}
+	f.Define(goyek.Task{
+		Name: "test",
+		Action: func(a *goyek.A) {
+			runExec(a, "SECRET=password echo hello")
+		},
+	})
+
+	oldFlow := goyek.DefaultFlow
+	defer func() { goyek.DefaultFlow = oldFlow }()
+	goyek.DefaultFlow = f
+	goyek.Use(mw)
+
+	_ = f.Execute(context.Background(), []string{"test"})
+
+	got := sb.String()
+	if strings.Contains(got, "password") {
+		t.Errorf("Secret value from runExec was logged: %s", got)
+	}
+	if !strings.Contains(got, "SECRET=[MASKED]") {
+		t.Errorf("Secret was not masked in logs: %s", got)
+	}
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -89,6 +89,37 @@ func ClearEnv() Option {
 	}
 }
 
+// Mask returns the command line with masked environment variables.
+func Mask(cmdLine string) string {
+	envs, args, err := shellwords.ParseWithEnvs(cmdLine)
+	if err != nil || (len(envs) == 0 && len(args) == 0) {
+		return cmdLine
+	}
+
+	var sb strings.Builder
+	for _, env := range envs {
+		if sb.Len() > 0 {
+			sb.WriteByte(' ')
+		}
+		key, _, _ := strings.Cut(env, "=")
+		sb.WriteString(key)
+		sb.WriteString("=[MASKED]")
+	}
+	for _, arg := range args {
+		if sb.Len() > 0 {
+			sb.WriteByte(' ')
+		}
+		if strings.Contains(arg, " ") {
+			sb.WriteByte('"')
+			sb.WriteString(arg)
+			sb.WriteByte('"')
+		} else {
+			sb.WriteString(arg)
+		}
+	}
+	return sb.String()
+}
+
 // Stdin is an option to set the standard input.
 func Stdin(r io.Reader) Option {
 	return func(_ *goyek.A, cmd *exec.Cmd) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -175,3 +175,54 @@ func TestExec_EnvOnly(t *testing.T) {
 	}()
 	Exec(&goyek.A{}, "FOO=bar")
 }
+
+func TestMask(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdLine string
+		want    string
+	}{
+		{
+			name:    "empty",
+			cmdLine: "",
+			want:    "",
+		},
+		{
+			name:    "no env vars",
+			cmdLine: "echo hello",
+			want:    "echo hello",
+		},
+		{
+			name:    "single env var",
+			cmdLine: "FOO=bar echo hello",
+			want:    "FOO=[MASKED] echo hello",
+		},
+		{
+			name:    "multiple env vars",
+			cmdLine: "FOO=bar BAZ=qux echo hello",
+			want:    "FOO=[MASKED] BAZ=[MASKED] echo hello",
+		},
+		{
+			name:    "args with spaces",
+			cmdLine: `echo "hello world"`,
+			want:    `echo "hello world"`,
+		},
+		{
+			name:    "env var and args with spaces",
+			cmdLine: `FOO=bar echo "hello world"`,
+			want:    `FOO=[MASKED] echo "hello world"`,
+		},
+		{
+			name:    "invalid command line",
+			cmdLine: `echo "hello world`,
+			want:    `echo "hello world`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Mask(tt.cmdLine); got != tt.want {
+				t.Errorf("Mask() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I have implemented a security enhancement to prevent secret leakage in build logs.

Key changes:
- Added `cmd.Mask(cmdLine string) string` which parses a command line and masks leading environment variable assignments (e.g., `FOO=bar` becomes `FOO=[MASKED]`).
- Updated `build/helper.go`'s `runExec` function to use `cmd.Mask` before logging the command with `a.Log`.
- Added comprehensive unit tests for `cmd.Mask` in `cmd/cmd_test.go`.
- Added a security regression test in `build/security_test.go` to ensure `runExec` correctly masks secrets in the output logs.
- Verified that all tests pass across the entire project.

This enhancement ensures that if a developer runs a command like `API_KEY=secret ./deploy`, the secret value will not be recorded in the build output.

---
*PR created automatically by Jules for task [17839867278675378179](https://jules.google.com/task/17839867278675378179) started by @pellared*