### PR TITLE
Migrate from client9/misspell to golangci/misspell

### DIFF
--- a/build/go.mod
+++ b/build/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 replace github.com/goyek/x => ../
 
 require (
-	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint/v2 v2.11.4
+	github.com/golangci/misspell v0.8.0
 	github.com/goyek/goyek/v3 v3.0.2-0.20260721120123-b290996180dc
 	github.com/goyek/x v0.0.0-00010101000000-000000000000
 )
@@ -91,7 +91,6 @@ require (
 	github.com/golangci/go-printf-func-name v0.1.1 // indirect
 	github.com/golangci/gofmt v0.0.0-20250106114630-d62b90e6713d // indirect
 	github.com/golangci/golines v0.15.0 // indirect
-	github.com/golangci/misspell v0.8.0 // indirect
 	github.com/golangci/plugin-module-register v0.1.2 // indirect
 	github.com/golangci/revgrep v0.8.0 // indirect
 	github.com/golangci/swaggoswag v0.0.0-20250504205917-77f2aca3143e // indirect

--- a/build/go.sum
+++ b/build/go.sum
@@ -144,7 +144,6 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/ckaznocha/intrange v0.3.1 h1:j1onQyXvHUsPWujDH6WIjhyH26gkRt/txNlV7LspvJs=
 github.com/ckaznocha/intrange v0.3.1/go.mod h1:QVepyz1AkUoFQkpEqksSYpNpUo3c5W7nWh/s6SHIJJk=
-github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/build/spell.go
+++ b/build/spell.go
@@ -10,7 +10,7 @@ var spell = goyek.Define(goyek.Task{
 	Name:  "spell",
 	Usage: "misspell",
 	Action: func(a *goyek.A) {
-		if !runExec(a, "go install github.com/client9/misspell/cmd/misspell", runDir(a, dirBuild)) {
+		if !runExec(a, "go install github.com/golangci/misspell/cmd/misspell", runDir(a, dirBuild)) {
 			return
 		}
 		mdFiles := find(a, ".md")

--- a/build/tools.go
+++ b/build/tools.go
@@ -7,6 +7,6 @@ package main
 // https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 // https://github.com/golang/go/issues/25922
 import (
-	_ "github.com/client9/misspell/cmd/misspell"
+	_ "github.com/golangci/misspell/cmd/misspell"
 	_ "github.com/golangci/golangci-lint/v2/cmd/golangci-lint"
 )


### PR DESCRIPTION
Migrated the spell checker tool from `client9/misspell` to the maintained `golangci/misspell` fork. This involved updating `build/tools.go`, `build/spell.go`, and running `go mod tidy` in the `build/` directory. All unit tests and the modified spell-checker task were verified to execute successfully.

---
*PR created automatically by Jules for task [3620938525990472939](https://jules.google.com/task/3620938525990472939) started by @pellared*